### PR TITLE
Feature/aggregation based on decision table

### DIFF
--- a/app/controllers/setup/invoices_controller.rb
+++ b/app/controllers/setup/invoices_controller.rb
@@ -77,14 +77,20 @@ class Setup::InvoicesController < PrivateController
 
     invoicing_request.invoices = invoicing_request.invoices.sort_by(&:date)
     rescue Rules::SolvingError => e
+      log(e)
       flash[:alert] = "Failed to simulate invoice : #{e.class.name} #{e.message} : <br>#{e.facts_and_rules.map {|k,v| [k,v].join(" : ")}.join(" <br>")}".html_safe
     rescue => e
+      log(e)
       flash[:alert] = "Failed to simulate invoice : #{e.class.name} #{e.message}"
     end
     render :new
   end
 
   private
+
+  def log(exception)
+    puts " #{exception.message} : \n#{exception.backtrace.join("\n")}"
+  end
 
   def invoice_params
     params.require(:invoicing_request)

--- a/app/controllers/setup/packages_controller.rb
+++ b/app/controllers/setup/packages_controller.rb
@@ -10,6 +10,7 @@ class Setup::PackagesController < PrivateController
   def update
     @package = current_project.packages.find(params[:id])
     package.update_attributes(params_package)
+    package.kind = package.ogs_reference.present? ? "multi-groupset" : "single"
 
     update_package_constants
 

--- a/app/controllers/setup/rules_controller.rb
+++ b/app/controllers/setup/rules_controller.rb
@@ -26,7 +26,7 @@ class Setup::RulesController < PrivateController
     end
 
     @rule = current_package.rules.build(
-      rule_params.merge(kind: kind,
+      rule_params.merge(kind:    kind,
                         package: current_package)
     )
     puts @rule.valid?

--- a/app/controllers/setup/rules_controller.rb
+++ b/app/controllers/setup/rules_controller.rb
@@ -9,7 +9,7 @@ class Setup::RulesController < PrivateController
       return
     end
 
-    @rule = current_package.rules.build(kind: current_package.missing_rules_kind.first)
+    @rule = current_package.rules.build(kind: kind)
     @rule.formulas.build(rule: @rule)
   end
 
@@ -25,7 +25,10 @@ class Setup::RulesController < PrivateController
       return
     end
 
-    @rule = current_package.rules.build(rule_params.merge(kind: current_package.missing_rules_kind.first, package: current_package))
+    @rule = current_package.rules.build(
+      rule_params.merge(kind: kind,
+                        package: current_package)
+    )
     puts @rule.valid?
     puts @rule.errors.full_messages
     if @rule.save
@@ -50,6 +53,14 @@ end
   end
 
   private
+
+  def kind
+    if params[:kind]
+      (current_package.missing_rules_kind & [params[:kind]]).first
+    else
+      current_package.missing_rules_kind.first
+    end
+  end
 
   def current_package
     @package ||= current_project.packages.find(params[:package_id])

--- a/app/models/decision_table.rb
+++ b/app/models/decision_table.rb
@@ -33,7 +33,7 @@ class DecisionTable < ApplicationRecord
     available_codes = rule.package.activities.map(&:code).compact
     available_codes += ["*"]
     invalid_rules = decision_table.rules.reject { |rule| available_codes.include?(rule["in:activity_code"]) }
-    invalid_rules.each { |invalid_rule| errors[:content] << "#{invalid_rule} not in available package codes #{available_codes}!" }
+    invalid_rules.each { |invalid_rule| errors[:content] << "#{invalid_rule.inspect} not in available package codes #{available_codes}!" }
   end
 
   def in_headers

--- a/app/models/decision_table.rb
+++ b/app/models/decision_table.rb
@@ -12,7 +12,7 @@ class DecisionTable < ApplicationRecord
   delegate :project_id, to: :rule
   delegate :program_id, to: :rule
 
-  belongs_to :rule, inverse_of: :formulas
+  belongs_to :rule, inverse_of: :decision_tables
 
   validate :in_headers_belong_to_facts
 
@@ -23,7 +23,7 @@ class DecisionTable < ApplicationRecord
   def in_headers_belong_to_facts
     in_headers.each do |header|
       unless HEADER_PREFIXES.include?(header) || header.starts_with?("groupset_code_")
-        errors[:content] << "Not in available org unit facts !"
+        errors[:content] << "Not '#{header}' in available org unit facts !"
       end
     end
   end
@@ -31,6 +31,7 @@ class DecisionTable < ApplicationRecord
   def in_activity_code_exists
     return unless in_headers.include?("activity_code")
     available_codes = rule.package.activities.map(&:code).compact
+    available_codes += ["*"]
     invalid_rules = decision_table.rules.reject { |rule| available_codes.include?(rule["in:activity_code"]) }
     invalid_rules.each { |invalid_rule| errors[:content] << "#{invalid_rule} not in available package codes #{available_codes}!" }
   end

--- a/app/models/decision_table.rb
+++ b/app/models/decision_table.rb
@@ -18,7 +18,7 @@ class DecisionTable < ApplicationRecord
 
   validate :in_activity_code_exists
 
-  HEADER_PREFIXES = %w[level_1 level_2 level_3 level_4 level_5 level_6 activity_code].freeze
+  HEADER_PREFIXES = %w[level_1 level_2 level_3 level_4 level_5 level_6 level activity_code].freeze
 
   def in_headers_belong_to_facts
     in_headers.each do |header|

--- a/app/models/package.rb
+++ b/app/models/package.rb
@@ -57,6 +57,10 @@ class Package < ApplicationRecord
     activities.flat_map(&:activity_states).select { |activity_state| activity_state.state == state }
   end
 
+  def multi_entities?
+    kind == "multi-groupset"
+  end
+
   def periods(year_month)
     return [] unless activity_rule
     used_variables_for_values = activity_rule.used_variables_for_values
@@ -75,10 +79,7 @@ class Package < ApplicationRecord
   end
 
   def missing_rules_kind
-    supported_rules_kind = %w[activity package]
-    supported_rules_kind.delete("activity") if activity_rule
-    supported_rules_kind.delete("package") if package_rule
-    supported_rules_kind
+    %w[activity package multi-entities] - rules.map(&:kind)
   end
 
   def apply_for(entity)
@@ -107,12 +108,16 @@ class Package < ApplicationRecord
     frequency_to_apply == frequency
   end
 
+  def multi_entities_rule
+    rules.find(&:multi_entities_kind?)
+  end
+
   def package_rule
-    rules.find { |r| r.kind == "package" }
+    rules.find(&:package_kind?)
   end
 
   def activity_rule
-    rules.find { |r| r.kind == "activity" }
+    rules.find(&:activity_kind?)
   end
 
   def kind_multi?

--- a/app/models/rule.rb
+++ b/app/models/rule.rb
@@ -105,6 +105,10 @@ class Rule < ApplicationRecord
       var_names << available_variables_for_values.map { |code| "%{#{code}}" }
       var_names << "quarter_of_year"
       var_names << "month_of_year"
+      if package.multi_entities?
+        var_names << "org_units_sum_if_count" if package.multi_entities_rule
+        var_names << "org_units_count"
+      end
     elsif package_kind?
       var_names << package.states.select(&:package_level?).map(&:code) if package
       var_names << available_variables_for_values.map { |code| "%{#{code}}" }
@@ -155,9 +159,11 @@ class Rule < ApplicationRecord
   def fake_facts
     if activity_kind?
       # in case we are in a clone packages a not there so go through long road package_states instead of states
-      facts = to_fake_facts(package.package_states.map(&:state).select(&:activity_level?)).merge(
-        Analytics::Locations::LevelScope.new.to_fake_facts(package)
-      )
+      facts = to_fake_facts(package.package_states.map(&:state).select(&:activity_level?))
+              .merge(
+                Analytics::Locations::LevelScope.new.to_fake_facts(package)
+              )
+              .merge("org_units_count" => "1", "org_units_sum_if_count" => "1" )
       facts
     elsif package_kind?
       # in case we are in a clone packages a not there so go through long road package_states instead of states

--- a/app/models/rule.rb
+++ b/app/models/rule.rb
@@ -163,7 +163,7 @@ class Rule < ApplicationRecord
               .merge(
                 Analytics::Locations::LevelScope.new.to_fake_facts(package)
               )
-              .merge("org_units_count" => "1", "org_units_sum_if_count" => "1" )
+              .merge("org_units_count" => "1", "org_units_sum_if_count" => "1")
       facts
     elsif package_kind?
       # in case we are in a clone packages a not there so go through long road package_states instead of states

--- a/app/services/analytics/cached_analytics_service.rb
+++ b/app/services/analytics/cached_analytics_service.rb
@@ -6,13 +6,14 @@ module Analytics
       @org_units_by_package = org_units_by_package
       @values_by_data_element_and_period = @values.group_by { |value| [value["data_element"], value["period"]] }
       @aggregation_per_data_elements = aggregation_per_data_elements
+      @entity_builder = Invoicing::EntityBuilder.new
     end
 
     def entities; end
 
     def activity_and_values(package, date)
       year_month = Periods.year_month(date)
-      org_unit_ids = @org_units_by_package[package].map(&:id)
+      org_unit_ids = @org_units_by_package[package].map(&:id).to_set
       values = package.activities.map do |activity|
         [
           activity,
@@ -28,6 +29,7 @@ module Analytics
 
     def build_facts(package, activity, year_month, org_unit_ids)
       facts = facts_for_period(
+        package,
         activity,
         Timeframe.current.periods(package, year_month),
         org_unit_ids
@@ -69,18 +71,34 @@ module Analytics
       variables
     end
 
-    def facts_for_period(activity, periods, org_unit_ids)
+    def facts_for_period(package, activity, periods, org_unit_ids)
+      @org_unit_facts_by_org_id ||= {}
       activity.activity_states.select(&:external_reference?).map do |activity_state|
         activity_values = []
         periods.map do |formatted_period|
-          activity_values += @values_by_data_element_and_period[[activity_state.external_reference, formatted_period.to_dhis2]] || []
+          activity_values += @values_by_data_element_and_period[
+            [activity_state.external_reference, formatted_period.to_dhis2]
+          ] || []
         end
         activity_values = activity_values.select { |v| org_unit_ids.include?(v.org_unit) }
+        if package.multi_entities_rule && org_unit_ids.size > 1
+          activity_values = activity_values.select do |v|
+            sum_if?(package, activity, v.org_unit)
+          end
+        end
         [activity_state.state.code, aggregation(activity_values, activity_state)]
       end.to_h
     end
 
+    def sum_if?(package, activity, org_unit_id)
+      @org_unit_facts_by_org_id[[package.id, activity.id, org_unit_id]] ||= @entity_builder.to_entity(@org_units_by_package[package].find { |org_unit| org_unit.id == org_unit_id }).facts
+      facts = package.multi_entities_rule.extra_facts(activity, @org_unit_facts_by_org_id[[package.id, activity.id, org_unit_id]])
+      puts " #{package.name} #{activity.name} #{facts}"
+      facts["sum_if"] == "true"
+    end
+
     def aggregation(activity_values, activity_state)
+      puts "aggregating : #{values}" if activity_values.size > 1
       aggregation_type = @aggregation_per_data_elements[activity_state.external_reference] || "SUM"
       values_for_activity = activity_values.map { |v| v["value"] }.map(&:to_f)
 

--- a/app/services/analytics/cached_analytics_service.rb
+++ b/app/services/analytics/cached_analytics_service.rb
@@ -110,7 +110,8 @@ module Analytics
         @org_units_by_package[package].find { |org_unit| org_unit.id == org_unit_id }
       ).facts
       facts = package.multi_entities_rule.extra_facts(activity, @org_unit_facts_by_org_id[[package.id, activity.id, org_unit_id]])
-      log_debug(" #{package.name} #{activity.name} #{facts} #{@org_unit_facts_by_org_id[[package.id, activity.id, org_unit_id]]}")
+      log_debug(" #{package.name} / #{activity.name} - #{activity.code} > #{facts} : #{@org_unit_facts_by_org_id[[package.id, activity.id, org_unit_id]]}")
+
       facts["sum_if"] == "true"
     end
 

--- a/app/services/analytics/locations/level_scope.rb
+++ b/app/services/analytics/locations/level_scope.rb
@@ -15,6 +15,7 @@ module Analytics
         level_dependencies.map do |state_level|
           state = vars[state_level]
           values_for_period = service.facts_for_period(
+            package,
             activity,
             Analytics::Timeframe.current.periods(package, year_month),
             [parent_org_unit_id(org_units, state_level, activity, package)]

--- a/app/services/analytics/timeframe/cycle.rb
+++ b/app/services/analytics/timeframe/cycle.rb
@@ -24,7 +24,7 @@ module Analytics
 
       def build_variables(package, activity, year_month, org_unit_ids, service)
         previous_facts = periods(package, year_month).map do |period|
-          service.facts_for_period(activity, [period], org_unit_ids)
+          service.facts_for_period(package, activity, [period], org_unit_ids)
         end
 
         activities_states = activity.activity_states.select(&:external_reference?)

--- a/app/services/analytics/timeframe/previous_year.rb
+++ b/app/services/analytics/timeframe/previous_year.rb
@@ -18,7 +18,7 @@ module Analytics
         variables = {}
 
         previous_facts = periods(package, year_month).map do |period|
-          [period, service.facts_for_period(activity, [period], org_unit_ids)]
+          [period, service.facts_for_period(package, activity, [period], org_unit_ids)]
         end.to_h
 
         activity.activity_states.map do |activity_state|

--- a/app/services/decision/table.rb
+++ b/app/services/decision/table.rb
@@ -45,7 +45,7 @@ module Decision
 
     def initialize(csv_string)
       csv = CSV.parse(csv_string, headers: true)
-      @headers = csv.headers
+      @headers = csv.headers.compact
 
       @rules = csv.map do |row|
         Rule.new(@headers, row)

--- a/app/services/decision/table.rb
+++ b/app/services/decision/table.rb
@@ -1,8 +1,9 @@
 require "csv"
 module Decision
   class Rule
-    def initialize(headers, row)
+    def initialize(headers, row, index)
       @headers = headers
+      @index = index
       @row = headers.map do |header|
         [header, row[header] ? row[header].strip : nil]
       end.to_h
@@ -13,7 +14,9 @@ module Decision
     end
 
     def specific_score(_hash)
-      headers("in:").select { |header| @row[header] == "*" }.size
+      header_in = headers("in:")
+      star_count = header_in.select { |header| @row[header] == "*" }.size
+      [header_in.size - star_count, -1 * @index]
     end
 
     def headers(type)
@@ -47,8 +50,8 @@ module Decision
       csv = CSV.parse(csv_string, headers: true)
       @headers = csv.headers.compact
 
-      @rules = csv.map do |row|
-        Rule.new(@headers, row)
+      @rules = csv.each_with_index.map do |row, index|
+        Rule.new(@headers, row, index)
       end
     end
 
@@ -65,7 +68,9 @@ module Decision
       matching_rules = @rules.select { |rule| rule.matches?(hash) }
 
       if matching_rules.any?
-        matching_rules.sort_by { |rule| rule.specific_score(hash) }
+        if matching_rules.size > 1
+          matching_rules = matching_rules.sort_by { |rule| rule.specific_score(hash) }
+        end
         return matching_rules.last.apply
       end
 

--- a/app/services/invoicing/entity_builder.rb
+++ b/app/services/invoicing/entity_builder.rb
@@ -26,6 +26,7 @@ module Invoicing
                         .map { |parent_id, index| ["level_#{index + 1}", parent_id] }
                         .to_h
       facts.merge(to_group_set_facts(org_unit))
+           .merge("level" => "#{parent_ids.size}")
     end
 
     def to_group_set_facts(org_unit)

--- a/app/services/rules/solver.rb
+++ b/app/services/rules/solver.rb
@@ -45,6 +45,7 @@ module Rules
     end
 
     def validate_formulas(rule)
+      return if rule.formulas.empty?
       facts = {}.merge(rule.fake_facts)
       rule.formulas.each do |formula|
         facts[formula.code] = mock_values(formula.expression, rule.available_variables_for_values)

--- a/app/views/setup/invoices/_invoice.html.erb
+++ b/app/views/setup/invoices/_invoice.html.erb
@@ -4,7 +4,7 @@
   <a name="<%= (package.name+"-"+invoice.date.strftime('%Y-%m')).underscore%>"></a>
   <h2><%= package.name %> at <%=invoice.date.strftime('%Y-%m')%>  </h2>
 
-  org unit(s) : <%= package.linked_org_units(@org_unit, @pyramid).map(&:name).join(" and ") %><br>
+  org unit(s) : <%= package.linked_org_units(@org_unit, @pyramid).map(&:name).join(", ") %><br>
   <%  periods = package.periods(Periods.year_month(invoice.date)) %>
   date range : <%= periods.map { |period| [period.start_date, period.end_date] }.flatten.minmax.map(&:to_s).join(' <i class="fa fa-arrow-right" aria-hidden="true"></i> ').html_safe %> <br>
   periods : <%= periods.map(&:to_dhis2).join(", ") %><br>

--- a/app/views/setup/rules/_form.html.erb
+++ b/app/views/setup/rules/_form.html.erb
@@ -26,8 +26,10 @@
 </div>
 <% end %>
 
-<%= f.simple_fields_for :formulas do |formula| %>
-  <%= render 'setup/rules/formula_fields', :f => formula %>
+<% unless rule.multi_entities_kind? %>
+  <%= f.simple_fields_for :formulas do |formula| %>
+    <%= render 'setup/rules/formula_fields', :f => formula %>
+  <% end %>
 <% end %>
 
 <div class="links">
@@ -38,4 +40,7 @@
 </div>
 
 <%= render "setup/rules/decision_tables", rule: rule, f: f%>
-<%= render "setup/rules/graph", rule: rule %>
+
+<% unless rule.multi_entities_kind? %>
+   <%= render "setup/rules/graph", rule: rule %>
+<% end %>

--- a/app/views/setup/setup/_rule.html.erb
+++ b/app/views/setup/setup/_rule.html.erb
@@ -1,10 +1,27 @@
 <tr>
+
+
     <td title="<%= package.package_entity_groups.map{ |entitygroup|  %Q(#{entitygroup.name}) }.join(', ') %> - <%= package.states.map{ |state|  %Q(#{state.name}) }.join(', ') %>">
     <%= package.name %><br><br>
-    <%= package.frequency %>
+    <%= package.frequency %><br><br>
+    <%= package.package_entity_groups.map(&:name).join(",")%>
     </td>
+
+    <td>
+    <% if package.multi_entities_rule%>
+        <%= link_to( package.multi_entities_rule.name,
+                     edit_setup_project_package_rule_path(project, package, package.multi_entities_rule) ,
+                     class: package.activity_rule.invalid? ? 'btn btn-danger' :'')
+        %>
+
+    <% elsif package.ogs_reference.present?%>
+      Keep "sum" everything or <br>
+      <%= link_to 'Create new rule', new_setup_project_package_rule_path(project, package, kind: 'multi-entities') , class: 'btn btn-default' %>
+    <% end %>
+    </td>
+
     <td valign="top">
-        <div class="col-md-4">
+        <div class="col-md-8">
           <%if readonly %>
              <%= package.activity_rule.name if package.activity_rule.present? %>
           <% else %>
@@ -17,8 +34,7 @@
                 <%= link_to 'Create new rule', new_setup_project_package_rule_path(project, package) , class: 'btn btn-warning' %>
             <% end %>
           <%end%>
-        </div>
-        <div class="col-md-8">
+
             <% if package.activity_rule.present? %>
              <%= render partial: "rule_formulas", locals: { formulas: package.activity_rule.formulas, readonly: readonly }%>
             <%end%>
@@ -26,7 +42,7 @@
     </td>
 
     <td valign="top">
-        <div class="col-md-4">
+        <div class="col-md-8">
             <%if readonly %>
               <%= package.package_rule.name  if package.package_rule.present?%>
             <% else %>
@@ -37,8 +53,6 @@
                 <%= link_to 'Create new rule', new_setup_project_package_rule_path(project, package)  , class: 'btn btn-warning' %>
               <% end %>
             <%end%>
-          </div>
-        <div class="col-md-8">
             <% if package.package_rule.present? %>
                <%= render partial: "rule_formulas", locals: { formulas: package.package_rule.formulas, readonly: readonly }%>
             <% end %>

--- a/app/views/setup/setup/_step_rules.html.erb
+++ b/app/views/setup/setup/_step_rules.html.erb
@@ -3,8 +3,9 @@
       <thead>
           <tr>
               <th>Package</th>
-              <th>Activity rule(s)</th>
-              <th>Package rule(s)</th>
+              <th>Multi entities rule</th>
+              <th>Activity rule</th>
+              <th>Package rule</th>
           </tr>
       </thead>
       <body>

--- a/app/workers/invoices_for_entities_worker.rb
+++ b/app/workers/invoices_for_entities_worker.rb
@@ -223,7 +223,7 @@ class InvoicesForEntitiesWorker
       end_date:          data_range.last,
       children:          false
     }
-
+    puts "fetching values #{values_query.to_json}"
     values = dhis2.data_value_sets.list(values_query)
     values.data_values ? values.values : []
   end

--- a/spec/controllers/setup/rules_controller_spec.rb
+++ b/spec/controllers/setup/rules_controller_spec.rb
@@ -1,0 +1,123 @@
+require "rails_helper"
+
+RSpec.describe Setup::RulesController, type: :controller do
+  include_context "basic_context"
+
+  describe "When non authenticated #new" do
+    it "should redirect to sign on" do
+      get :new, params: { project_id: 1, package_id: 2 }
+      expect(response).to redirect_to("/users/sign_in")
+    end
+  end
+
+  describe "When authenticated" do
+    before(:each) do
+      sign_in user
+    end
+
+    let(:program) { create :program }
+
+    let(:project) do
+      project = full_project
+
+      project.save!
+      user.program = program
+      user.save!
+      user.reload
+
+      project
+    end
+
+    let(:package) { project.packages.first }
+
+    def delete_existing_project_rules
+      project.payment_rules.destroy_all
+      expect(Rule.all.count).to eq(8)
+    end
+
+    describe "#new" do
+      it "should render new edit form" do
+        get :new, params: {
+          "package_id" => package.id,
+
+          "project_id" => project.id
+        }
+        expect(response).to have_http_status(200)
+      end
+
+      it "should render new form" do
+        project.payment_rules.destroy_all
+        get :new, params: {
+          "project_id" => project.id,
+          "package_id" => package.id
+        }
+      end
+    end
+
+    describe "#create" do
+      it "should create a rule with formula and decision table" do
+        post :create, params: {
+          "package_id" => package.id,
+          "project_id" => project.id,
+          rule: {
+            name: "sample rule"
+          }
+        }
+        expect(flash[:notice]).to eq("Rule created !")
+        expect(response).to redirect_to("/")
+        expect(Rule.last.name).to eq("sample rule")
+      end
+
+      it "should render new form" do
+        project.payment_rules.destroy_all
+        post :create, params: {
+          "project_id" => project.id,
+          "package_id" => package.id,
+          rule: { name: nil, kind: nil }
+        }
+        expect(assigns(:rule).valid?).to eq(false)
+        expect(response).to have_http_status(200)
+        expect(response.body).to include("Name can&#39;t be blank ")
+      end
+    end
+
+    describe "#edit" do
+      it "should show and edit form" do
+        get :edit, params: {
+          "project_id" => project.id,
+          "package_id" => package.id,
+          "id"         => package.activity_rule.id
+        }
+      end
+    end
+
+    describe "#update" do
+      it "should validate and render errors" do
+        post :update, params: {
+          "project_id" => project.id,
+          "package_id" => package.id,
+          id: package.activity_rule.id,
+          rule: { name: nil, kind: "multi-entities" }
+        }
+        expect(assigns(:rule).valid?).to eq(false)
+        expect(response).to have_http_status(200)
+        expect(response.body).to include("Name can&#39;t be blank ")
+      end
+
+      it "should update" do
+        post :update, params: {
+          "package_id" => package.id,
+            "project_id" => project.id,
+            id: package.activity_rule.id,
+            rule: {
+              name: "sample rule 2"
+            }
+        }
+        expect(flash[:notice]).to eq("Rule updated !")
+        expect(response).to redirect_to("/")
+        package.activity_rule.reload
+        expect(package.activity_rule.name).to eq("sample rule 2")
+      end
+    end
+  end
+end

--- a/spec/fixtures/dhis2/data_set_values_multi_entities.json
+++ b/spec/fixtures/dhis2/data_set_values_multi_entities.json
@@ -1,0 +1,117 @@
+{
+  "dataValues": [
+    {
+      "dataElement": "dhjgLt7EYmu",
+      "period": "201501",
+      "orgUnit": "CV4IXOSr5ky",
+      "categoryOptionCombo": "se1qWfbtkmx",
+      "attributeOptionCombo": "ylVaBBv3gZv",
+      "value": "0",
+      "storedBy": "p_mandizvidza",
+      "lastUpdated": "2015-06-01T21:42:30.114+0000",
+      "followUp": false
+    },
+    {
+      "dataElement": "dhjgLt7EYmu",
+      "period": "201502",
+      "orgUnit": "CV4IXOSr5ky",
+      "categoryOptionCombo": "se1qWfbtkmx",
+      "attributeOptionCombo": "ylVaBBv3gZv",
+      "value": "5",
+      "storedBy": "p_mandizvidza",
+      "lastUpdated": "2015-06-02T21:04:28.388+0000",
+      "followUp": false
+    },
+    {
+      "dataElement": "xtVtnuWBBLB",
+      "period": "201501",
+      "orgUnit": "CV4IXOSr5ky",
+      "categoryOptionCombo": "se1qWfbtkmx",
+      "attributeOptionCombo": "ylVaBBv3gZv",
+      "value": "0.05",
+      "storedBy": "p_bvumbe",
+      "lastUpdated": "2015-05-26T04:10:21.481+0000",
+      "followUp": false
+    },
+    {
+      "dataElement": "xtVtnuWBBLB",
+      "period": "201502",
+      "orgUnit": "CV4IXOSr5ky",
+      "categoryOptionCombo": "se1qWfbtkmx",
+      "attributeOptionCombo": "ylVaBBv3gZv",
+      "value": "0.05",
+      "storedBy": "p_bvumbe",
+      "lastUpdated": "2015-05-26T04:10:56.641+0000",
+      "followUp": false
+    },
+    {
+      "dataElement": "xtVtnuWBBLB",
+      "period": "201602",
+      "orgUnit": "CV4IXOSr5ky",
+      "categoryOptionCombo": "ylVaBBv3gZv",
+      "attributeOptionCombo": "ylVaBBv3gZv",
+      "value": "0.05",
+      "storedBy": "kudzai",
+      "created": "2016-10-20T14:05:18.000+0000",
+      "lastUpdated": "2016-06-26T04:11:37.000+0000",
+      "followUp": false
+    },
+    // PMa2VCrupOd
+    {
+      "dataElement": "dhjgLt7EYmu",
+      "period": "201501",
+      "orgUnit": "PMa2VCrupOd",
+      "categoryOptionCombo": "se1qWfbtkmx",
+      "attributeOptionCombo": "ylVaBBv3gZv",
+      "value": "0",
+      "storedBy": "p_mandizvidza",
+      "lastUpdated": "2015-06-01T21:42:30.114+0000",
+      "followUp": false
+    },
+    {
+      "dataElement": "dhjgLt7EYmu",
+      "period": "201502",
+      "orgUnit": "PMa2VCrupOd",
+      "categoryOptionCombo": "se1qWfbtkmx",
+      "attributeOptionCombo": "ylVaBBv3gZv",
+      "value": "5",
+      "storedBy": "p_mandizvidza",
+      "lastUpdated": "2015-06-02T21:04:28.388+0000",
+      "followUp": false
+    },
+    {
+      "dataElement": "xtVtnuWBBLB",
+      "period": "201501",
+      "orgUnit": "PMa2VCrupOd",
+      "categoryOptionCombo": "se1qWfbtkmx",
+      "attributeOptionCombo": "ylVaBBv3gZv",
+      "value": "0.05",
+      "storedBy": "p_bvumbe",
+      "lastUpdated": "2015-05-26T04:10:21.481+0000",
+      "followUp": false
+    },
+    {
+      "dataElement": "xtVtnuWBBLB",
+      "period": "201502",
+      "orgUnit": "PMa2VCrupOd",
+      "categoryOptionCombo": "se1qWfbtkmx",
+      "attributeOptionCombo": "ylVaBBv3gZv",
+      "value": "0.05",
+      "storedBy": "p_bvumbe",
+      "lastUpdated": "2015-05-26T04:10:56.641+0000",
+      "followUp": false
+    },
+    {
+      "dataElement": "xtVtnuWBBLB",
+      "period": "201602",
+      "orgUnit": "PMa2VCrupOd",
+      "categoryOptionCombo": "ylVaBBv3gZv",
+      "attributeOptionCombo": "ylVaBBv3gZv",
+      "value": "0.05",
+      "storedBy": "kudzai",
+      "created": "2016-10-20T14:05:18.000+0000",
+      "lastUpdated": "2016-06-26T04:11:37.000+0000",
+      "followUp": false
+    }
+  ]
+}

--- a/spec/fixtures/dhis2/organisation_unit_group_sets.json
+++ b/spec/fixtures/dhis2/organisation_unit_group_sets.json
@@ -1,1 +1,177 @@
-{"pager":{"page":1,"pageCount":1,"total":4,"pageSize":50000},"organisationUnitGroupSets":[{"code":"Area","lastUpdated":"2017-01-26T17:45:53.259","id":"uIuxlbV1vRT","href":"https://play.dhis2.org/demo/api/organisationUnitGroupSets/uIuxlbV1vRT","created":"2017-01-26T17:45:53.259","name":"Area","shortName":"Area","dimensionType":"ORGANISATION_UNIT_GROUP_SET","displayName":"Area","publicAccess":"rw------","displayShortName":"Area","externalAccess":false,"dimension":"uIuxlbV1vRT","allItems":false,"compulsory":false,"includeSubhierarchyInAnalytics":true,"dataDimension":true,"access":{"read":true,"update":true,"externalize":false,"delete":true,"write":true,"manage":true},"user":{"id":"GOLswS44mh8"},"translations":[],"organisationUnitGroups":[{"id":"nlX2VoouN63"},{"id":"J40PpdN4Wkk"},{"id":"jqBqIXoXpfy"},{"id":"b0EsAxm8Nge"}],"userGroupAccesses":[],"attributeValues":[],"userAccesses":[],"items":[{"id":"nlX2VoouN63"},{"id":"J40PpdN4Wkk"},{"id":"jqBqIXoXpfy"},{"id":"b0EsAxm8Nge"}]},{"lastUpdated":"2014-04-06T11:23:07.660","id":"Bpx0589u8y0","href":"https://play.dhis2.org/demo/api/organisationUnitGroupSets/Bpx0589u8y0","created":"2011-12-24T12:24:24.041","name":"Facility Ownership","shortName":"Facility Ownership","dimensionType":"ORGANISATION_UNIT_GROUP_SET","displayName":"Facility Ownership","description":"Facility Ownership","displayShortName":"Facility Ownership","externalAccess":false,"dimension":"Bpx0589u8y0","displayDescription":"Facility Ownership","allItems":false,"compulsory":true,"includeSubhierarchyInAnalytics":false,"dataDimension":true,"access":{"read":true,"update":true,"externalize":false,"delete":true,"write":true,"manage":true},"translations":[],"organisationUnitGroups":[{"id":"PVLOW4bCshG"},{"id":"oRVt7g429ZO"},{"id":"MAs88nJc9nL"},{"id":"w0gFTTmsUcF"}],"userGroupAccesses":[],"attributeValues":[],"userAccesses":[],"items":[{"id":"PVLOW4bCshG"},{"id":"oRVt7g429ZO"},{"id":"MAs88nJc9nL"},{"id":"w0gFTTmsUcF"}]},{"lastUpdated":"2014-04-06T11:23:19.310","id":"J5jldMd8OHv","href":"https://play.dhis2.org/demo/api/organisationUnitGroupSets/J5jldMd8OHv","created":"2012-04-27T18:05:54.088","name":"Facility Type","shortName":"Facility Type","dimensionType":"ORGANISATION_UNIT_GROUP_SET","displayName":"Facility Type","description":"Facility Type","displayShortName":"Facility Type","externalAccess":false,"dimension":"J5jldMd8OHv","displayDescription":"Facility Type","allItems":false,"compulsory":true,"includeSubhierarchyInAnalytics":false,"dataDimension":true,"access":{"read":true,"update":true,"externalize":false,"delete":true,"write":true,"manage":true},"translations":[],"organisationUnitGroups":[{"id":"uYxK4wmcPqA"},{"id":"CXw2yu5fodb"},{"id":"EYbopBOJWsW"},{"id":"RXL3lPSK8oG"},{"id":"tDZVQ1WtwpA"}],"userGroupAccesses":[],"attributeValues":[],"userAccesses":[],"items":[{"id":"uYxK4wmcPqA"},{"id":"CXw2yu5fodb"},{"id":"EYbopBOJWsW"},{"id":"RXL3lPSK8oG"},{"id":"tDZVQ1WtwpA"}]},{"lastUpdated":"2013-05-29T13:44:52.641","id":"Cbuj0VCyDjL","href":"https://play.dhis2.org/demo/api/organisationUnitGroupSets/Cbuj0VCyDjL","created":"2013-03-06T17:05:58.879","name":"Location Rural/Urban","shortName":"Location Rural/Urban","dimensionType":"ORGANISATION_UNIT_GROUP_SET","displayName":"Location Rural/Urban","description":"Location Rural/Urban","displayShortName":"Location Rural/Urban","externalAccess":false,"dimension":"Cbuj0VCyDjL","displayDescription":"Location Rural/Urban","allItems":false,"compulsory":true,"includeSubhierarchyInAnalytics":false,"dataDimension":true,"access":{"read":true,"update":true,"externalize":false,"delete":true,"write":true,"manage":true},"translations":[],"organisationUnitGroups":[{"id":"f25dqv3Y7Z0"},{"id":"GGghZsfu7qV"}],"userGroupAccesses":[],"attributeValues":[],"userAccesses":[],"items":[{"id":"f25dqv3Y7Z0"},{"id":"GGghZsfu7qV"}]}]}
+{
+  "pager": { "page": 1, "pageCount": 1, "total": 4, "pageSize": 50000 },
+  "organisationUnitGroupSets": [
+    {
+      "code": "Area",
+      "lastUpdated": "2017-01-26T17:45:53.259",
+      "id": "uIuxlbV1vRT",
+      "href":
+        "https://play.dhis2.org/demo/api/organisationUnitGroupSets/uIuxlbV1vRT",
+      "created": "2017-01-26T17:45:53.259",
+      "name": "Area",
+      "shortName": "Area",
+      "dimensionType": "ORGANISATION_UNIT_GROUP_SET",
+      "displayName": "Area",
+      "publicAccess": "rw------",
+      "displayShortName": "Area",
+      "externalAccess": false,
+      "dimension": "uIuxlbV1vRT",
+      "allItems": false,
+      "compulsory": false,
+      "includeSubhierarchyInAnalytics": true,
+      "dataDimension": true,
+      "access": {
+        "read": true,
+        "update": true,
+        "externalize": false,
+        "delete": true,
+        "write": true,
+        "manage": true
+      },
+      "user": { "id": "GOLswS44mh8" },
+      "translations": [],
+      "organisationUnitGroups": [
+        { "id": "nlX2VoouN63" },
+        { "id": "J40PpdN4Wkk" },
+        { "id": "jqBqIXoXpfy" },
+        { "id": "b0EsAxm8Nge" }
+      ],
+      "userGroupAccesses": [],
+      "attributeValues": [],
+      "userAccesses": [],
+      "items": [
+        { "id": "nlX2VoouN63" },
+        { "id": "J40PpdN4Wkk" },
+        { "id": "jqBqIXoXpfy" },
+        { "id": "b0EsAxm8Nge" }
+      ]
+    },
+    {
+      "lastUpdated": "2014-04-06T11:23:07.660",
+      "id": "Bpx0589u8y0",
+      "href":
+        "https://play.dhis2.org/demo/api/organisationUnitGroupSets/Bpx0589u8y0",
+      "created": "2011-12-24T12:24:24.041",
+      "name": "Facility Ownership",
+      "shortName": "Facility Ownership",
+      "dimensionType": "ORGANISATION_UNIT_GROUP_SET",
+      "displayName": "Facility Ownership",
+      "description": "Facility Ownership",
+      "displayShortName": "Facility Ownership",
+      "externalAccess": false,
+      "dimension": "Bpx0589u8y0",
+      "displayDescription": "Facility Ownership",
+      "allItems": false,
+      "compulsory": true,
+      "includeSubhierarchyInAnalytics": false,
+      "dataDimension": true,
+      "access": {
+        "read": true,
+        "update": true,
+        "externalize": false,
+        "delete": true,
+        "write": true,
+        "manage": true
+      },
+      "translations": [],
+      "organisationUnitGroups": [
+        { "id": "PVLOW4bCshG" },
+        { "id": "oRVt7g429ZO" },
+        { "id": "MAs88nJc9nL" },
+        { "id": "w0gFTTmsUcF" }
+      ],
+      "userGroupAccesses": [],
+      "attributeValues": [],
+      "userAccesses": [],
+      "items": [
+        { "id": "PVLOW4bCshG" },
+        { "id": "oRVt7g429ZO" },
+        { "id": "MAs88nJc9nL" },
+        { "id": "w0gFTTmsUcF" }
+      ]
+    },
+    {
+      "lastUpdated": "2014-04-06T11:23:19.310",
+      "id": "J5jldMd8OHv",
+      "href":
+        "https://play.dhis2.org/demo/api/organisationUnitGroupSets/J5jldMd8OHv",
+      "created": "2012-04-27T18:05:54.088",
+      "name": "Facility Type",
+      "shortName": "Facility Type",
+      "dimensionType": "ORGANISATION_UNIT_GROUP_SET",
+      "displayName": "Facility Type",
+      "description": "Facility Type",
+      "displayShortName": "Facility Type",
+      "externalAccess": false,
+      "dimension": "J5jldMd8OHv",
+      "displayDescription": "Facility Type",
+      "allItems": false,
+      "compulsory": true,
+      "includeSubhierarchyInAnalytics": false,
+      "dataDimension": true,
+      "access": {
+        "read": true,
+        "update": true,
+        "externalize": false,
+        "delete": true,
+        "write": true,
+        "manage": true
+      },
+      "translations": [],
+      "organisationUnitGroups": [
+        { "id": "uYxK4wmcPqA" },
+        { "id": "CXw2yu5fodb" },
+        { "id": "EYbopBOJWsW" },
+        { "id": "RXL3lPSK8oG" },
+        { "id": "tDZVQ1WtwpA" }
+      ],
+      "userGroupAccesses": [],
+      "attributeValues": [],
+      "userAccesses": [],
+      "items": [
+        { "id": "uYxK4wmcPqA" },
+        { "id": "CXw2yu5fodb" },
+        { "id": "EYbopBOJWsW" },
+        { "id": "RXL3lPSK8oG" },
+        { "id": "tDZVQ1WtwpA" }
+      ]
+    },
+    {
+      "lastUpdated": "2013-05-29T13:44:52.641",
+      "id": "Cbuj0VCyDjL",
+      "href":
+        "https://play.dhis2.org/demo/api/organisationUnitGroupSets/Cbuj0VCyDjL",
+      "created": "2013-03-06T17:05:58.879",
+      "name": "Location Rural/Urban",
+      "shortName": "Location Rural/Urban",
+      "dimensionType": "ORGANISATION_UNIT_GROUP_SET",
+      "displayName": "Location Rural/Urban",
+      "description": "Location Rural/Urban",
+      "displayShortName": "Location Rural/Urban",
+      "externalAccess": false,
+      "dimension": "Cbuj0VCyDjL",
+      "displayDescription": "Location Rural/Urban",
+      "allItems": false,
+      "compulsory": true,
+      "includeSubhierarchyInAnalytics": false,
+      "dataDimension": true,
+      "access": {
+        "read": true,
+        "update": true,
+        "externalize": false,
+        "delete": true,
+        "write": true,
+        "manage": true
+      },
+      "translations": [],
+      "organisationUnitGroups": [
+        { "id": "f25dqv3Y7Z0" },
+        { "id": "GGghZsfu7qV" }
+      ],
+      "userGroupAccesses": [],
+      "attributeValues": [],
+      "userAccesses": [],
+      "items": [{ "id": "f25dqv3Y7Z0" }, { "id": "GGghZsfu7qV" }]
+    }
+  ]
+}

--- a/spec/fixtures/scorpio/decision_table_multi_entities.csv
+++ b/spec/fixtures/scorpio/decision_table_multi_entities.csv
@@ -1,0 +1,5 @@
+in:activity_code,in:level,in:groupset_code_facility_ownership,out:sum_if
+vaccination,4,mission,false
+clients_sous_traitement_arv_suivi_pendant_les_6_premiers_mois,3,public_facilities,false
+clients_sous_traitement_arv_suivi_pendant_les_6_premiers_mois,4,public_facilities,false
+*,*,*,true

--- a/spec/fixtures/scorpio/invoice_multi_entities.json
+++ b/spec/fixtures/scorpio/invoice_multi_entities.json
@@ -1,0 +1,334 @@
+{
+  "dataValues": [
+    {
+      "dataElement": "Vaccination-difference_percentage",
+      "orgUnit": "vRC0stJ5y9Q",
+      "period": "201501",
+      "value": "33.3333333333333333",
+      "comment": "A-difference_percentage-Vaccination"
+    },
+    {
+      "dataElement": "Vaccination-quantity",
+      "orgUnit": "vRC0stJ5y9Q",
+      "period": "201501",
+      "value": "9.0",
+      "comment": "A-quantity-Vaccination"
+    },
+    {
+      "dataElement": "Vaccination-amount",
+      "orgUnit": "vRC0stJ5y9Q",
+      "period": "201501",
+      "value": 72,
+      "comment": "A-amount-Vaccination"
+    },
+    {
+      "dataElement": "Vaccination-org_units_count_exported",
+      "orgUnit": "vRC0stJ5y9Q",
+      "period": "201501",
+      "value": 51,
+      "comment": "A-org_units_count_exported-Vaccination"
+    },
+    {
+      "dataElement": "Vaccination-org_units_sum_if_count_exported",
+      "orgUnit": "vRC0stJ5y9Q",
+      "period": "201501",
+      "value": 49,
+      "comment": "A-org_units_sum_if_count_exported-Vaccination"
+    },
+    {
+      "dataElement":
+        "Clients sous traitement ARV suivi pendant les 6 premiers mois-difference_percentage",
+      "orgUnit": "vRC0stJ5y9Q",
+      "period": "201501",
+      "value": "75.0",
+      "comment":
+        "A-difference_percentage-Clients sous traitement ARV suivi pendant les 6 premiers mois"
+    },
+    {
+      "dataElement":
+        "Clients sous traitement ARV suivi pendant les 6 premiers mois-quantity",
+      "orgUnit": "vRC0stJ5y9Q",
+      "period": "201501",
+      "value": "0.0",
+      "comment":
+        "A-quantity-Clients sous traitement ARV suivi pendant les 6 premiers mois"
+    },
+    {
+      "dataElement":
+        "Clients sous traitement ARV suivi pendant les 6 premiers mois-amount",
+      "orgUnit": "vRC0stJ5y9Q",
+      "period": "201501",
+      "value": 0,
+      "comment":
+        "A-amount-Clients sous traitement ARV suivi pendant les 6 premiers mois"
+    },
+    {
+      "dataElement":
+        "Clients sous traitement ARV suivi pendant les 6 premiers mois-org_units_count_exported",
+      "orgUnit": "vRC0stJ5y9Q",
+      "period": "201501",
+      "value": 51,
+      "comment":
+        "A-org_units_count_exported-Clients sous traitement ARV suivi pendant les 6 premiers mois"
+    },
+    {
+      "dataElement":
+        "Clients sous traitement ARV suivi pendant les 6 premiers mois-org_units_sum_if_count_exported",
+      "orgUnit": "vRC0stJ5y9Q",
+      "period": "201501",
+      "value": 24,
+      "comment":
+        "A-org_units_sum_if_count_exported-Clients sous traitement ARV suivi pendant les 6 premiers mois"
+    },
+    {
+      "dataElement": "Vaccination-difference_percentage",
+      "orgUnit": "vRC0stJ5y9Q",
+      "period": "201502",
+      "value": "33.3333333333333333",
+      "comment": "A-difference_percentage-Vaccination"
+    },
+    {
+      "dataElement": "Vaccination-quantity",
+      "orgUnit": "vRC0stJ5y9Q",
+      "period": "201502",
+      "value": "9.0",
+      "comment": "A-quantity-Vaccination"
+    },
+    {
+      "dataElement": "Vaccination-amount",
+      "orgUnit": "vRC0stJ5y9Q",
+      "period": "201502",
+      "value": 72,
+      "comment": "A-amount-Vaccination"
+    },
+    {
+      "dataElement": "Vaccination-org_units_count_exported",
+      "orgUnit": "vRC0stJ5y9Q",
+      "period": "201502",
+      "value": 51,
+      "comment": "A-org_units_count_exported-Vaccination"
+    },
+    {
+      "dataElement": "Vaccination-org_units_sum_if_count_exported",
+      "orgUnit": "vRC0stJ5y9Q",
+      "period": "201502",
+      "value": 49,
+      "comment": "A-org_units_sum_if_count_exported-Vaccination"
+    },
+    {
+      "dataElement":
+        "Clients sous traitement ARV suivi pendant les 6 premiers mois-difference_percentage",
+      "orgUnit": "vRC0stJ5y9Q",
+      "period": "201502",
+      "value": "75.0",
+      "comment":
+        "A-difference_percentage-Clients sous traitement ARV suivi pendant les 6 premiers mois"
+    },
+    {
+      "dataElement":
+        "Clients sous traitement ARV suivi pendant les 6 premiers mois-quantity",
+      "orgUnit": "vRC0stJ5y9Q",
+      "period": "201502",
+      "value": "0.0",
+      "comment":
+        "A-quantity-Clients sous traitement ARV suivi pendant les 6 premiers mois"
+    },
+    {
+      "dataElement":
+        "Clients sous traitement ARV suivi pendant les 6 premiers mois-amount",
+      "orgUnit": "vRC0stJ5y9Q",
+      "period": "201502",
+      "value": 0,
+      "comment":
+        "A-amount-Clients sous traitement ARV suivi pendant les 6 premiers mois"
+    },
+    {
+      "dataElement":
+        "Clients sous traitement ARV suivi pendant les 6 premiers mois-org_units_count_exported",
+      "orgUnit": "vRC0stJ5y9Q",
+      "period": "201502",
+      "value": 51,
+      "comment":
+        "A-org_units_count_exported-Clients sous traitement ARV suivi pendant les 6 premiers mois"
+    },
+    {
+      "dataElement":
+        "Clients sous traitement ARV suivi pendant les 6 premiers mois-org_units_sum_if_count_exported",
+      "orgUnit": "vRC0stJ5y9Q",
+      "period": "201502",
+      "value": 24,
+      "comment":
+        "A-org_units_sum_if_count_exported-Clients sous traitement ARV suivi pendant les 6 premiers mois"
+    },
+    {
+      "dataElement": "Vaccination-difference_percentage",
+      "orgUnit": "vRC0stJ5y9Q",
+      "period": "201503",
+      "value": "33.3333333333333333",
+      "comment": "A-difference_percentage-Vaccination"
+    },
+    {
+      "dataElement": "Vaccination-quantity",
+      "orgUnit": "vRC0stJ5y9Q",
+      "period": "201503",
+      "value": "9.0",
+      "comment": "A-quantity-Vaccination"
+    },
+    {
+      "dataElement": "Vaccination-amount",
+      "orgUnit": "vRC0stJ5y9Q",
+      "period": "201503",
+      "value": 72,
+      "comment": "A-amount-Vaccination"
+    },
+    {
+      "dataElement": "Vaccination-org_units_count_exported",
+      "orgUnit": "vRC0stJ5y9Q",
+      "period": "201503",
+      "value": 51,
+      "comment": "A-org_units_count_exported-Vaccination"
+    },
+    {
+      "dataElement": "Vaccination-org_units_sum_if_count_exported",
+      "orgUnit": "vRC0stJ5y9Q",
+      "period": "201503",
+      "value": 49,
+      "comment": "A-org_units_sum_if_count_exported-Vaccination"
+    },
+    {
+      "dataElement":
+        "Clients sous traitement ARV suivi pendant les 6 premiers mois-difference_percentage",
+      "orgUnit": "vRC0stJ5y9Q",
+      "period": "201503",
+      "value": "75.0",
+      "comment":
+        "A-difference_percentage-Clients sous traitement ARV suivi pendant les 6 premiers mois"
+    },
+    {
+      "dataElement":
+        "Clients sous traitement ARV suivi pendant les 6 premiers mois-quantity",
+      "orgUnit": "vRC0stJ5y9Q",
+      "period": "201503",
+      "value": "0.0",
+      "comment":
+        "A-quantity-Clients sous traitement ARV suivi pendant les 6 premiers mois"
+    },
+    {
+      "dataElement":
+        "Clients sous traitement ARV suivi pendant les 6 premiers mois-amount",
+      "orgUnit": "vRC0stJ5y9Q",
+      "period": "201503",
+      "value": 0,
+      "comment":
+        "A-amount-Clients sous traitement ARV suivi pendant les 6 premiers mois"
+    },
+    {
+      "dataElement":
+        "Clients sous traitement ARV suivi pendant les 6 premiers mois-org_units_count_exported",
+      "orgUnit": "vRC0stJ5y9Q",
+      "period": "201503",
+      "value": 51,
+      "comment":
+        "A-org_units_count_exported-Clients sous traitement ARV suivi pendant les 6 premiers mois"
+    },
+    {
+      "dataElement":
+        "Clients sous traitement ARV suivi pendant les 6 premiers mois-org_units_sum_if_count_exported",
+      "orgUnit": "vRC0stJ5y9Q",
+      "period": "201503",
+      "value": 24,
+      "comment":
+        "A-org_units_sum_if_count_exported-Clients sous traitement ARV suivi pendant les 6 premiers mois"
+    },
+    {
+      "dataElement": "Vaccination-attributed_points",
+      "orgUnit": "vRC0stJ5y9Q",
+      "period": "2015Q1",
+      "value": "6.0",
+      "comment": "A-attributed_points-Vaccination"
+    },
+    {
+      "dataElement": "Vaccination-max_points",
+      "orgUnit": "vRC0stJ5y9Q",
+      "period": "2015Q1",
+      "value": "7.0",
+      "comment": "A-max_points-Vaccination"
+    },
+    {
+      "dataElement": "Vaccination-quality_technical_score_value",
+      "orgUnit": "vRC0stJ5y9Q",
+      "period": "2015Q1",
+      "value": "85.7142857142857143",
+      "comment": "A-quality_technical_score_value-Vaccination"
+    },
+    {
+      "dataElement":
+        "Clients sous traitement ARV suivi pendant les 6 premiers mois-attributed_points",
+      "orgUnit": "vRC0stJ5y9Q",
+      "period": "2015Q1",
+      "value": "1.0",
+      "comment":
+        "A-attributed_points-Clients sous traitement ARV suivi pendant les 6 premiers mois"
+    },
+    {
+      "dataElement":
+        "Clients sous traitement ARV suivi pendant les 6 premiers mois-max_points",
+      "orgUnit": "vRC0stJ5y9Q",
+      "period": "2015Q1",
+      "value": "2.0",
+      "comment":
+        "A-max_points-Clients sous traitement ARV suivi pendant les 6 premiers mois"
+    },
+    {
+      "dataElement":
+        "Clients sous traitement ARV suivi pendant les 6 premiers mois-quality_technical_score_value",
+      "orgUnit": "vRC0stJ5y9Q",
+      "period": "2015Q1",
+      "value": "50.0",
+      "comment":
+        "A-quality_technical_score_value-Clients sous traitement ARV suivi pendant les 6 premiers mois"
+    },
+    {
+      "dataElement": "package-quantity_total_pma",
+      "orgUnit": "vRC0stJ5y9Q",
+      "period": "201501",
+      "value": "72.0",
+      "comment": "P-quantity_total_pma-Quantity PMA"
+    },
+    {
+      "dataElement": "package-quantity_total_pma",
+      "orgUnit": "vRC0stJ5y9Q",
+      "period": "201502",
+      "value": "72.0",
+      "comment": "P-quantity_total_pma-Quantity PMA"
+    },
+    {
+      "dataElement": "package-quantity_total_pma",
+      "orgUnit": "vRC0stJ5y9Q",
+      "period": "201503",
+      "value": "72.0",
+      "comment": "P-quantity_total_pma-Quantity PMA"
+    },
+    {
+      "dataElement": "package-attributed_points",
+      "orgUnit": "vRC0stJ5y9Q",
+      "period": "2015Q1",
+      "value": "7.0",
+      "comment": "P-attributed_points-Quality"
+    },
+    {
+      "dataElement": "package-max_points",
+      "orgUnit": "vRC0stJ5y9Q",
+      "period": "2015Q1",
+      "value": "9.0",
+      "comment": "P-max_points-Quality"
+    },
+    {
+      "dataElement": "package-quality_technical_score_value",
+      "orgUnit": "vRC0stJ5y9Q",
+      "period": "2015Q1",
+      "value": "77.77777777777778",
+      "comment": "P-quality_technical_score_value-Quality"
+    }
+  ]
+}

--- a/spec/services/invoicing/entity_builder_spec.rb
+++ b/spec/services/invoicing/entity_builder_spec.rb
@@ -25,6 +25,7 @@ RSpec.describe Invoicing::EntityBuilder do
       "level_2"                            => "O6uvpzGd5pu",
       "level_3"                            => "U6Kr7Gtpidn",
       "level_4"                            => "vRC0stJ5y9Q",
+      "level"                              => "4",
       "groupset_code_facility_ownership"   => "private_clinic",
       "groupset_code_facility_type"        => "clinic",
       "groupset_code_location_rural_urban" => "rural"


### PR DESCRIPTION
don't apply a "sum" on everything for multiple entities rules, allow to filter based on level, groupsets,...
the out:sum_if colum will used to filter the values

![image](https://user-images.githubusercontent.com/371692/33871827-7dcdb086-df14-11e7-962c-548494432e5b.png)

two variables will be available in the activity rule :
  -  `org_units_count` : count of orgunits in the same group of the specified groupset
  - and `org_units_sum_if_count` : number of org units in the same group of the specified groupset and match the decision table 

for decision tables you know have access to 
  - level
  - and * are allowed in the activity_code matching
  - in case of equality in number of '*' the first matching will be used