### PR TITLE
Allow to only fetch active regions in orgunit snapshots

### DIFF
--- a/app/controllers/setup/main_entity_groups_controller.rb
+++ b/app/controllers/setup/main_entity_groups_controller.rb
@@ -33,6 +33,6 @@ class Setup::MainEntityGroupsController < PrivateController
   end
 
   def entity_group_params
-    params.require(:entity_group).permit(:name, :external_reference)
+    params.require(:entity_group).permit(:name, :external_reference, :limit_snaphot_to_active_regions)
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -34,4 +34,8 @@ class User < ApplicationRecord
   def env_dev?
     Rails.env.dev?
   end
+
+  def label
+    "User##{id} - #{email}"
+  end
 end

--- a/app/views/setup/setup/_step_entities.html.erb
+++ b/app/views/setup/setup/_step_entities.html.erb
@@ -15,10 +15,19 @@
                                 url:organisation_unit_group_setup_project_autocomplete_index_path(project, term:'')
                               } %>
 
+
+
+
+
         </div>
     </div>
     <div class="col-md-6" id="main_target_group_selection"></div>
 </div>
+<%= f.input :limit_snaphot_to_active_regions,
+            hint: "To limit memory usage and speed up invoicing, "\
+            "take only the level_2 and their children if at least one of the children belongs to target group. "\
+            "Eg : 40.000 organisation units but only 2 regions actually"\
+            " in the target groups and so only need 3000 of them." %>
 <%= f.button :submit, class: "btn btn-success" %>
 <% end %>
 <% end %>

--- a/app/workers/dhis2_snapshot_worker.rb
+++ b/app/workers/dhis2_snapshot_worker.rb
@@ -3,8 +3,9 @@
 class Dhis2SnapshotWorker
   include Sidekiq::Worker
   include Sidekiq::Throttled::Worker
-  PAGE_SIZE = 5000
   sidekiq_options retry: 5
+
+  PAGE_SIZE = 5000
 
   sidekiq_throttle(
     concurrency: { limit: 1 },
@@ -49,34 +50,31 @@ class Dhis2SnapshotWorker
     snapshot.job_id = jid || "railsc"
     snapshot.dhis2_version = dhis2_version
     Dhis2SnapshotCompactor.new.compact(snapshot)
-    puts "#{Time.new} \tCompacted #{kind} total time : #{Time.new - start})"
+    log_progress("Compacted", kind, start)
     snapshot.disable_tracking = @disable_tracking
     snapshot.save!
-    puts "#{Time.new} \tProcessed #{kind} : #{Time.new - start})"
+    log_progress("tProcessed", kind, start)
     Rails.logger.info "Dhis2SnapshotWorker #{kind} : for project anchor #{new_snapshot ? 'created' : 'updated'} #{year} #{month} : #{project.project_anchor.id} #{project.name} #{data.size} done!"
     snapshot
   end
 
+  def log_progress(message, kind, start)
+    puts "#{Time.new} \t#{message} #{kind} total time : #{Time.new - start})"
+  end
+
+  ORGANISATION_UNITS_FIELDS = [
+    ":all",
+    "!coordinates", "!ancestors", "!access", "!attributeValues", "!users",
+    "!dataSets", "!userGroupAccesses", "!dimensionItemType", "!externalAccess"
+  ].join(",")
+
   def fetch_data(project, kind)
-    data = []
-    begin
-      start = Time.new
-      dhis2 = project.dhis2_connection
-      paged_data = dhis2.send(kind).list(fields: ":all", page_size: PAGE_SIZE)
-      data.push(*paged_data)
-      page_count = paged_data.pager.page_count
-      puts "#{Time.new} \t Processed page 1 of #{page_count} (Size: #{paged_data.size}, total time : #{Time.new - start})"
-      if page_count > 1
-        (2..page_count).each do |page|
-          paged_data = dhis2.send(kind).list(fields: ":all", page_size: PAGE_SIZE, page: page)
-          data.push(*paged_data)
-          puts "#{Time.new} \t Processed page #{page} of #{page_count} (Size: #{paged_data.size}, total time : #{Time.new - start})"
-        end
-      end
-    rescue RestClient::Exception => e
-      Rails.logger.info "#{kind} #{e.message}"
-      raise "#{kind} #{e.message}"
-    end
-    data
+    fetcher = if kind == :organisation_units && project&.entity_group&.limit_snaphot_to_active_regions
+                Fetchers::OrganisationUnitsSnapshotFetcher.new(fields: ORGANISATION_UNITS_FIELDS)
+              else
+                Fetchers::GenericSnapshotFetcher.new
+              end
+
+    fetcher.fetch_data(project, kind)
   end
 end

--- a/app/workers/fetchers/generic_snapshot_fetcher.rb
+++ b/app/workers/fetchers/generic_snapshot_fetcher.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+module Fetchers
+  class GenericSnapshotFetcher
+    attr_reader :fields
+
+    def initialize(fields: ":all")
+      @fields = fields
+    end
+
+    def fetch_data(project, kind, filter: nil, page_size: 5000)
+      data = []
+      begin
+        start = Time.new
+        dhis2 = project.dhis2_connection
+        paged_data = dhis2.send(kind).list(fields: fields, page_size: page_size, filter: filter)
+        data.push(*paged_data)
+        page_count = paged_data.pager.page_count
+
+        log_progress(1, page_count, paged_data, start, filter)
+        if page_count > 1
+          (2..page_count).each do |page|
+            paged_data = dhis2.send(kind).list(fields: fields, page_size: page_size, page: page, filter: filter)
+            log_progress(page, page_count, paged_data, start, filter)
+            data.push(*paged_data)
+          end
+        end
+      rescue RestClient::Exception => e
+        Rails.logger.info "#{kind} #{e.message}"
+        raise "#{kind} #{e.message}"
+      end
+      data
+    end
+
+    def log_progress(page, page_count, paged_data, start, filter)
+      puts "#{Time.new} \t Processed page #{page} of #{page_count} "\
+            " (Size: #{paged_data.size}, total time : #{Time.new - start}) #{filter} #{fields}"
+    end
+  end
+end

--- a/app/workers/fetchers/organisation_units_snapshot_fetcher.rb
+++ b/app/workers/fetchers/organisation_units_snapshot_fetcher.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+module Fetchers
+  class OrganisationUnitsSnapshotFetcher
+    def initialize(fields:)
+      @fetcher = GenericSnapshotFetcher.new(fields: fields)
+    end
+
+    def fetch_data(project, kind)
+      raise "OrganisationUnitsSnapshotFetcher works only on organisation_units" unless kind == :organisation_units
+      filters = build_filters(project)
+      filters.each_with_object([]) do |filter, data|
+        data.push(*fetcher.fetch_data(project, kind, filter: filter))
+      end
+    end
+
+    private
+
+    attr_reader :fetcher
+
+    def build_filters(project)
+      paths = fetch_paths_for_contracted_entities(project)
+
+      region_paths = paths.map { |path| path.split("/")[0..2].join("/") }.uniq
+      country_paths = region_paths.map { |path| path.split("/")[0..1].join("/") }.uniq
+
+      filters = region_paths.map { |region_id| "path:like:#{region_id}" }
+      filters += country_paths.map { |country_id| "path:eq:#{country_id}" }
+
+      filters
+    end
+
+    def fetch_paths_for_contracted_entities(project)
+      path_holder = project.dhis2_connection
+                           .organisation_unit_groups
+                           .list(
+                             filter: "id:eq:" + project.entity_group.external_reference,
+                             fields: "organisationUnits[path]"
+                           )
+                           .first
+      path_holder.organisation_units.map { |ou| ou["path"] }
+    end
+  end
+end

--- a/config/initializers/rails_admin.rb
+++ b/config/initializers/rails_admin.rb
@@ -34,6 +34,11 @@ RailsAdmin.config do |config|
       only EDITABLE_MODELS
     end
   end
+  config.model "User" do
+    object_label_method do
+      :label
+    end
+  end
 
   config.model "Dhis2Log" do
     list do

--- a/db/migrate/20180911101255_add_limit_snapshot_entity_groups.rb
+++ b/db/migrate/20180911101255_add_limit_snapshot_entity_groups.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddLimitSnapshotEntityGroups < ActiveRecord::Migration[5.0]
+  def change
+    add_column :entity_groups, :limit_snaphot_to_active_regions, :boolean, default: false, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180810100805) do
+ActiveRecord::Schema.define(version: 20180911101255) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -98,8 +98,9 @@ ActiveRecord::Schema.define(version: 20180810100805) do
     t.string   "name"
     t.string   "external_reference"
     t.integer  "project_id"
-    t.datetime "created_at",         null: false
-    t.datetime "updated_at",         null: false
+    t.datetime "created_at",                                      null: false
+    t.datetime "updated_at",                                      null: false
+    t.boolean  "limit_snaphot_to_active_regions", default: false, null: false
     t.index ["project_id"], name: "index_entity_groups_on_project_id", using: :btree
   end
 
@@ -237,9 +238,9 @@ ActiveRecord::Schema.define(version: 20180810100805) do
     t.integer  "original_id"
     t.string   "cycle",                 default: "quarterly", null: false
     t.integer  "engine_version",        default: 1,           null: false
-    t.string   "qualifier"
     t.string   "default_coc_reference"
     t.string   "default_aoc_reference"
+    t.string   "qualifier"
     t.index ["project_anchor_id"], name: "index_projects_on_project_anchor_id", using: :btree
   end
 


### PR DESCRIPTION
add a flag to only fetch orgunits within "region" with at least one contracted entity.

![image](https://user-images.githubusercontent.com/371692/45361130-b4264780-b5d1-11e8-84ad-688539bb0448.png)

if test are conclusive enable by default on new project.
note that it affects the total displayed in target groups.

first tests show a good improvement in snapshot worker and invoice simulation, reduced nearly to 50% the time.

*with the flag off* 

```
2018-09-11 14:56:47 +0200 	 Processed page 1 of 11  (Size: 5000, total time : 19.156487904)  :all
2018-09-11 14:57:03 +0200 	 Processed page 2 of 11  (Size: 5000, total time : 35.253217884)  :all
2018-09-11 14:57:23 +0200 	 Processed page 3 of 11  (Size: 5000, total time : 54.956362651)  :all
2018-09-11 14:57:42 +0200 	 Processed page 4 of 11  (Size: 5000, total time : 73.890307692)  :all
2018-09-11 14:58:07 +0200 	 Processed page 5 of 11  (Size: 5000, total time : 99.303839699)  :all
2018-09-11 14:58:27 +0200 	 Processed page 6 of 11  (Size: 5000, total time : 119.106999424)  :all
2018-09-11 14:58:47 +0200 	 Processed page 7 of 11  (Size: 5000, total time : 139.097725453)  :all
2018-09-11 14:59:08 +0200 	 Processed page 8 of 11  (Size: 5000, total time : 159.591540001)  :all
2018-09-11 14:59:28 +0200 	 Processed page 9 of 11  (Size: 5000, total time : 179.419022727)  :all
2018-09-11 14:59:47 +0200 	 Processed page 10 of 11  (Size: 5000, total time : 199.26326212)  :all
2018-09-11 14:59:50 +0200 	 Processed page 11 of 11  (Size: 56, total time : 202.253723433)  :all
```

*with the flag on*

orgunits in snapshot : 9540 vs 50056 

```
2018-09-11 14:52:36 +0200 	 Processed page 1 of 1  (Size: 1252, total time : 2.713254346) path:like:/s5DPBsdoE8b/gzLOszDWdqM :all,!coordinates,!ancestors,!access,!attributeValues,!users,!dataSets,!userGroupAccesses,!dimensionItemType,!externalAccess
2018-09-11 14:52:38 +0200 	 Processed page 1 of 1  (Size: 1317, total time : 2.881129506) path:like:/s5DPBsdoE8b/r3IK5qdHsZ6 :all,!coordinates,!ancestors,!access,!attributeValues,!users,!dataSets,!userGroupAccesses,!dimensionItemType,!externalAccess
2018-09-11 14:52:41 +0200 	 Processed page 1 of 1  (Size: 1245, total time : 2.720919291) path:like:/s5DPBsdoE8b/OgjFloqKoqk :all,!coordinates,!ancestors,!access,!attributeValues,!users,!dataSets,!userGroupAccesses,!dimensionItemType,!externalAccess
2018-09-11 14:52:44 +0200 	 Processed page 1 of 1  (Size: 1175, total time : 2.571474636) path:like:/s5DPBsdoE8b/RLySnRCE1Gy :all,!coordinates,!ancestors,!access,!attributeValues,!users,!dataSets,!userGroupAccesses,!dimensionItemType,!externalAccess
2018-09-11 14:52:46 +0200 	 Processed page 1 of 1  (Size: 822, total time : 1.937681192) path:like:/s5DPBsdoE8b/Ym1fEhWFWYI :all,!coordinates,!ancestors,!access,!attributeValues,!users,!dataSets,!userGroupAccesses,!dimensionItemType,!externalAccess
2018-09-11 14:52:49 +0200 	 Processed page 1 of 1  (Size: 1578, total time : 3.320576827) path:like:/s5DPBsdoE8b/ziJ3yxfgb3m :all,!coordinates,!ancestors,!access,!attributeValues,!users,!dataSets,!userGroupAccesses,!dimensionItemType,!externalAccess
2018-09-11 14:52:51 +0200 	 Processed page 1 of 1  (Size: 813, total time : 1.912122732) path:like:/s5DPBsdoE8b/bSfaEpPFa9Y :all,!coordinates,!ancestors,!access,!attributeValues,!users,!dataSets,!userGroupAccesses,!dimensionItemType,!externalAccess
2018-09-11 14:52:54 +0200 	 Processed page 1 of 1  (Size: 1337, total time : 3.26752231) path:like:/s5DPBsdoE8b/jXngIDniC8t :all,!coordinates,!ancestors,!access,!attributeValues,!users,!dataSets,!userGroupAccesses,!dimensionItemType,!externalAccess
2018-09-11 14:52:54 +0200 	 Processed page 1 of 1  (Size: 1, total time : 0.283824025) path:eq:/s5DPBsdoE8b :all,!coordinates,!ancestors,!access,!attributeValues,!users,!dataSets,!userGroupAccesses,!dimensionItemType,!externalAccess
```
