### PR TITLE
Make Heroku deploys easier

### DIFF
--- a/app.json
+++ b/app.json
@@ -8,13 +8,14 @@
   },
   "env": {
     "ADMIN_PASSWORD": {
+      "description": "Password to log in to Rails Admin",
       "value": "sunday everyone promptly"
     },
     "SIDEKIQ_CONCURRENCY": {
       "value": 2
     },
     "LOG_LEVEL": {
-      "required": true
+      "value": "INFO"
     }
   },
   "formation": {

--- a/app.json
+++ b/app.json
@@ -1,0 +1,39 @@
+{
+  "name": "OpenRBF 2.0",
+  "description": "A rule engine on top of dhis2 developed by Bluesquare, to let power users describe their Results-Based Financing scheme.",
+  "logo": "https://bluesquarehub.files.wordpress.com/2017/01/logo-openrbf.png?w=151&h=147",
+  "keywords": ["ruby", "orbf", "openrbf"],
+  "scripts": {
+    "postdeploy": "bundle exec rake db:seed"
+  },
+  "env": {
+    "ADMIN_PASSWORD": {
+      "value": "sunday everyone promptly"
+    },
+    "SIDEKIQ_CONCURRENCY": {
+      "value": 2
+    },
+    "LOG_LEVEL": {
+      "required": true
+    },
+  },
+  "formation": {
+    "worker": {
+      "quantity": 1,
+      "size": "free"
+    },
+    "web": {
+      "quantity": 1,
+      "size": "free"
+    }
+  },
+  "addons": [
+    "heroku-postgresql",
+    "heroku-redis"
+  ],
+  "buildpacks": [
+    {
+      "url": "heroku/ruby"
+    }
+  ]
+}

--- a/app.json
+++ b/app.json
@@ -4,7 +4,7 @@
   "logo": "https://bluesquarehub.files.wordpress.com/2017/01/logo-openrbf.png?w=151&h=147",
   "keywords": ["ruby", "orbf", "openrbf"],
   "scripts": {
-    "postdeploy": "bundle exec rake db:seed"
+    "postdeploy": "bundle exec rake db:schema:load db:seed"
   },
   "env": {
     "ADMIN_PASSWORD": {

--- a/app.json
+++ b/app.json
@@ -15,7 +15,7 @@
     },
     "LOG_LEVEL": {
       "required": true
-    },
+    }
   },
   "formation": {
     "worker": {

--- a/app.json
+++ b/app.json
@@ -16,6 +16,10 @@
     },
     "LOG_LEVEL": {
       "value": "INFO"
+    },
+    "MALLOC_ARENA_MAX": {
+      "description": "Reduce memory needed",
+      "value": 2
     }
   },
   "formation": {

--- a/spec/config/lint_data_files_spec.rb
+++ b/spec/config/lint_data_files_spec.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+require "yaml"
+require "json"
+require "pathname"
+
+describe "app.json" do
+  it "loads from JSON" do
+    assert JSON.load(File.open(Rails.root.join("app.json")))
+  end
+end
+
+describe "locales" do
+  yaml_paths = Pathname.glob(Rails.root.join("config", "locales", "*.yml"))
+
+  yaml_paths.each do |path|
+    it "load from #{path}" do
+      assert YAML.load_file(path)
+    end
+  end
+end


### PR DESCRIPTION
Adding an app.json for two reasons:

- Ability to (technically) add a deploy button to the readme
- Allow for Review apps

The second one is the feature here. If we setup a pipeline on Heroku
this means that a PR can be deployed to a functioning application
Heroku with the press of a button.

It uses the app.json to setup a new app, which has the required env
variables and a redis and postgres set up and running, so it basically
removes any friction to set up an app to test out the PR.

https://devcenter.heroku.com/articles/heroku-button
https://devcenter.heroku.com/articles/app-json-schema#formation