### PR TITLE
Improve initial setup experience

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,5 @@ before_script:
   - cp config/database-travis.yml config/database.yml
   - psql -c 'create database orbf2_test;' -U postgres
 script:
-  - RAILS_ENV=test bundle exec rake db:migrate --trace
-  - bundle exec rake db:test:prepare
-  - "bundle exec rspec --color"
+  - script/cibuild
   - if [ "$TRAVIS_PULL_REQUEST" == "false" ]; then ./cc-test-reporter after-build --exit-code $TRAVIS_TEST_RESULT; fi

--- a/README.md
+++ b/README.md
@@ -41,46 +41,15 @@ Every change is tracked and you publish your project draft to be used at a given
 
 ## Dependencies and config
 
-First setup your local database configuration. We advise to use Postgresql as we make use of the built-in UUID format.
+Run `script/setup`, this should install all dependencies and create the local databases.
 
-```shell
-cp config/database-template.yml config/database.yml
-```
+Run `script/test` to check if everything was successfull.
 
-edit if necessary
-
-```shell
-cp config/application.template.yml config/application.yml
-```
-
-you can setup the admin password there
-
-## Setup the db and seed program and project
-
-```shell
-rake db:create
-rake db:migrate
-rake db:seed
-```
-
-## Seed a user and program
-
-Using the console or the seed file, create a program (a simple name) and a user connected to it:
-
-```ruby
-program = Program.create(code: "Sierra Leone")
-program.users.create(
-    password:"password",
-    password_confirmation:"password",
-    email: "admin@orbf.org"
-)
-```
-
-(this is done inside the seed file if you are in development mode)
+A default user and program will be create by the `db/seeds.rb` file.
 
 ## Seed a project
 
-We have an example project that can be created using DHIS2 public instance (https://play.dhis2.org/demo/) to showcase a RBF project configuration:
+We have an example project that can be created using the public DHIS2 demo instance (https://play.dhis2.org/demo/) to showcase a RBF project configuration:
 
 http://127.0.0.1:3000/setup/seeds
 
@@ -88,7 +57,7 @@ This will generate a "typical" RBF project with quality, quantity & payment rule
 
 ## Admin interface
 
-You can access any element in the application using the admin interface at 
+You can access any element in the application using the admin interface at
 
 http://127.0.0.1:3000/admin
 

--- a/README.md
+++ b/README.md
@@ -76,6 +76,10 @@ We recommand Heroku to host the application, but any hosting should work as long
     git push heroku master
     heroku run rake db:create db:migrate db:seed
 
+Or you can use this button to get up and running immediately:
+
+[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://heroku.com/deploy)
+
 ## Restoring a testing or production Environment
 
 get a fresh copy using Heroku

--- a/app.json
+++ b/app.json
@@ -8,8 +8,11 @@
   },
   "env": {
     "ADMIN_PASSWORD": {
-      "description": "Password to log in to Rails Admin",
-      "value": "sunday everyone promptly"
+      "description": "Password to log in to Rails Admin"
+    },
+    "DEFAULT_USER_EMAIL": {
+    },
+    "DEFAULT_USER_PASSWORD": {
     },
     "SIDEKIQ_CONCURRENCY": {
       "value": "2"

--- a/app.json
+++ b/app.json
@@ -25,6 +25,9 @@
     "MALLOC_ARENA_MAX": {
       "description": "https://devcenter.heroku.com/articles/tuning-glibc-memory-behavior",
       "value": "2"
+    },
+    "ORBF_STAGING": {
+      "description": "Designates it as a QA environment"
     }
   },
   "formation": {

--- a/app.json
+++ b/app.json
@@ -11,8 +11,10 @@
       "description": "Password to log in to Rails Admin"
     },
     "DEFAULT_USER_EMAIL": {
+      "description": "Email for the created user to log in with"
     },
     "DEFAULT_USER_PASSWORD": {
+      "description": "Password for the created user to log in with"
     },
     "SIDEKIQ_CONCURRENCY": {
       "value": "2"
@@ -21,7 +23,7 @@
       "value": "INFO"
     },
     "MALLOC_ARENA_MAX": {
-      "description": "Reduce memory needed",
+      "description": "https://devcenter.heroku.com/articles/tuning-glibc-memory-behavior",
       "value": "2"
     }
   },

--- a/app/controllers/setup/seeds_controller.rb
+++ b/app/controllers/setup/seeds_controller.rb
@@ -3,7 +3,7 @@ class Setup::SeedsController < PrivateController
     current_user.program.create_project_anchor unless current_user.program.project_anchor
     project_anchor = current_user.program.project_anchor
     project_factory = ProjectFactory.new
-    suffix = Time.now.to_s[0..15] + " - "
+    suffix = project_factory.normalized_suffix
     project = project_factory.build(
       dhis2_url:      dhis2_url,
       user:           "admin",
@@ -12,7 +12,7 @@ class Setup::SeedsController < PrivateController
       project_anchor: project_anchor
     )
     project_factory.update_links(project, suffix)
-
+    project_factory.additional_seed_actions(project, suffix)
     project_anchor.projects.destroy_all
     project_anchor.projects.push project
 

--- a/app/services/project_factory.rb
+++ b/app/services/project_factory.rb
@@ -273,6 +273,10 @@ class ProjectFactory
     hospital_group = { name: "Hospital",       organisation_unit_group_ext_ref: "tDZVQ1WtwpA" }
     clinic_group = {   name: "Clinic",         organisation_unit_group_ext_ref: "RXL3lPSK8oG" }
     admin_group = {    name: "Administrative", organisation_unit_group_ext_ref: "w0gFTTmsUcF" }
+    project.build_entity_group(
+      name: clinic_group[:name],
+      external_reference: clinic_group[:organisation_unit_group_ext_ref]
+    )
 
     [
       { name: "Claimed",           level: "activity" },

--- a/app/services/project_factory.rb
+++ b/app/services/project_factory.rb
@@ -339,6 +339,12 @@ class ProjectFactory
     default_quality_states = states_in(project,  ["Claimed", "Verified", "Max. Score"])
     default_performance_states = states_in(project, ["Claimed", "Max. Score", "Budget"])
 
+    # States have been created, now we can update them with actual
+    # identifiers from DHIS, these are taken from:
+    #
+    # https://play.dhis2.org/2.29/api/dataElements?filter=domainType:eq:AGGREGATE
+    #
+    # We don't really care what the elements are, we just need to map them.
     update_package_with_dhis2(
       project.packages[0], suffix, default_quantity_states,
       [clinic_group],

--- a/app/services/project_factory.rb
+++ b/app/services/project_factory.rb
@@ -1,3 +1,4 @@
+# coding: utf-8
 # frozen_string_literal: true
 
 class ProjectFactory
@@ -260,6 +261,10 @@ class ProjectFactory
   end
 
   def update_links(project, suffix = "")
+    if (suffix || "") =~ /^[0-9]/
+      # Packages should not start with a number
+      suffix = "P#{suffix}"
+    end
     project.build_entity_group(
       name:               "contracted entities",
       external_reference: "external_reference"

--- a/app/services/project_factory.rb
+++ b/app/services/project_factory.rb
@@ -294,12 +294,16 @@ class ProjectFactory
 
     claimed_state = project.states.find { |s| s.name == "Claimed" }
     tarif_state = project.states.find { |s| s.name == "Tarif" }
+    verified_state = project.states.find { |s| s.name == "Verified" }
+    max_state = project.states.find { |s| s.name == "Max. Score" }
 
     activity_1 = project.activities.build(
       project: project,
       name: "Vaccination", activity_states_attributes: [
         { name: "Vaccination claimed", state: claimed_state, external_reference: "cl-ext-1" },
-        { name: "tarif for Vaccination ", state: tarif_state, external_reference: "tarif-ext-1" }
+        { name: "tarif for Vaccination ", state: tarif_state, external_reference: "tarif-ext-1" },
+        { name: "Verified", state: verified_state, external_reference: 'verified-ext-1'},
+        { name: "Max. Score", state: max_state, external_reference: 'max-score-ext-1'}
       ]
     )
 
@@ -316,7 +320,9 @@ class ProjectFactory
           name:               "tarif for Clients sous traitement ARV suivi pendant les 6 premiers mois",
           state:              tarif_state,
           external_reference: "tarif-ext-2"
-        }
+        },
+        { name: "Verified", state: verified_state, external_reference: 'verified-ext-1'},
+        { name: "Max. Score", state: max_state, external_reference: 'max-score-ext-1'}
       ]
     )
 

--- a/config/application.rb
+++ b/config/application.rb
@@ -32,5 +32,8 @@ module Scorpio
         exception_object: event.payload[:exception_object] # the exception instance
       }
     end
+
+    # These are defined in `/lib/*.rb
+    require "scorpio"
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -36,7 +36,9 @@ Rails.application.routes.draw do
     namespace :setup do
       get "/projects/", to: "setup#index", as: "project_anchor"
       get "/projects/:project_id", to: "setup#index", as: "project"
-      resources :seeds, only: [:index] if Rails.env.development? || Rails.env.dev?
+      if Scorpio.is_dev?
+        resources :seeds, only: [:index]
+      end
       resources :projects, only: %i[create update] do
         resources :metadatas, only: %i[index update]
         resources :snapshots, only: [:create]

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -6,11 +6,11 @@
 #   movies = Movie.create([{ name: 'Star Wars' }, { name: 'Lord of the Rings' }])
 #   Character.create(name: 'Luke', movie: movies.first)
 
-if Rails.env == "development"
-  program = Program.create(code: "Sierra Leone")
-  program.users.create(
-    password:              "password",
-    password_confirmation: "password",
-    email:                 "admin@orbf.org"
-  )
+if Scorpio.is_dev?
+  program = Program.find_or_create_by(code: "Sierra Leone")
+  email = ENV.fetch("DEFAULT_USER_EMAIL", "admin@example.com")
+  password = ENV.fetch("DEFAULT_USER_PASSWORD", "12345678")
+  program.users.find_or_create_by(email: email) do |user|
+    user.password = user.password_confirmation = password
+  end
 end

--- a/lib/scorpio.rb
+++ b/lib/scorpio.rb
@@ -1,7 +1,11 @@
-module Scorpio
+# frozen_string_literal: true
 
-  # Development or QA environemnts will return true
+module Scorpio
+  # Development or QA environments will return true
+  # rubocop:disable Naming/PredicateName
+  # In this case, I think the `is_` actually provides some value
   def self.is_dev?
-    Rails.env.development? || ENV['ORBF_STAGING']
+    Rails.env.development? || ENV["ORBF_STAGING"]
   end
+  # rubocop:enable Naming/PredicateName
 end

--- a/lib/scorpio.rb
+++ b/lib/scorpio.rb
@@ -1,0 +1,7 @@
+module Scorpio
+
+  # Development or QA environemnts will return true
+  def self.is_dev?
+    Rails.env.development? || ENV['ORBF_STAGING']
+  end
+end

--- a/script/bootstrap
+++ b/script/bootstrap
@@ -1,0 +1,72 @@
+#!/bin/bash
+
+# script/bootstrap: Resolve all dependencies that the application requires to
+#                   run.
+
+set -e
+
+cd "$(dirname "$0")/.."
+
+if [ -f "Brewfile" ] && [ "$(uname -s)" = "Darwin" ]; then
+    brew bundle check >/dev/null 2>&1  || {
+        echo "==> Installing Homebrew dependencies…"
+        brew bundle
+    }
+fi
+
+echo "==> Checking ruby version..."
+if [[ $(ruby -v) =~ 2.5.1 ]]; then
+    true
+else
+    cat <<"RUBY"
+You need to install ruby 2.5.1
+
+I'd strongly suggest to use 'chruby' or 'rbenv' to manage rubies and make your
+development easier. I have a personal favor for 'chruby' so I'll explain that
+one.
+
+      1. Install 'chruby' as described here: https://github.com/postmodern/chruby
+      2. Install 'ruby-install' https://github.com/postmodern/ruby-install#readme
+      3. ruby-install ruby 2.5.1
+      4. In a new shell navigat to this folder and do 'chruby 2.5.1'
+      5. 'ruby -v' should now output ruby-2.5.1
+
+'rbenv' https://github.com/rbenv/rbenv has its own ruby installer etc, but chruby
+does less and does it better.
+
+Anyhoe, use the right ruby.
+RUBY
+    exit 1
+fi
+
+# Install bundler if needed
+which bundle >/dev/null 2>&1  || {
+    gem install bundler
+}
+
+# Install foreman if needed
+which foreman >/dev/null 2>&1 || {
+    gem install foreman
+}
+
+if [ -f "Gemfile" ]; then
+    echo "==> Installing gem dependencies…"
+    bundle check >/dev/null 2>&1  || {
+        bundle install --quiet --without production
+    }
+fi
+
+bundle exec ruby -e 'require "hesabu"; File.file?(Hesabu::HESABUCLI + "k") ? exit(0) : exit(1)' >/dev/null 2>&1  || {
+    cat <<HESABU
+You don't seem to have a binary for the hesabu gem.
+
+https://github.com/BLSQ/hesabu
+
+The easiest way to fix this is to download a release for your platform at:
+
+https://github.com/BLSQ/go-hesabu/releases
+
+And install it at $(bundle exec ruby -e 'require "hesabu"; puts Hesabu::HESABUCLI')
+HESABU
+    exit 1
+}

--- a/script/bootstrap
+++ b/script/bootstrap
@@ -68,5 +68,4 @@ https://github.com/BLSQ/go-hesabu/releases
 
 And install it at $(bundle exec ruby -e 'require "hesabu"; puts Hesabu::HESABUCLI')
 HESABU
-    exit 1
 }

--- a/script/cibuild
+++ b/script/cibuild
@@ -1,0 +1,21 @@
+#! /bin/sh
+#
+# Stop on error and output every command before executing it
+set -ex
+
+echo "[cibuild] started at..."
+date "+%H:%M:%S"
+
+export RAILS_ENV="test"
+export RACK_ENV="test"
+
+hostname
+
+bundle install
+bundle exec rake db:test:prepare
+
+echo "[cibuild] Running tests ..."
+date "+%H:%M:%S"
+
+# run tests.
+script/test

--- a/script/console
+++ b/script/console
@@ -1,0 +1,28 @@
+#!/bin/sh
+
+# script/console: Launch a console for the application. Optionally allow an
+#                 environment to be passed in to let the script handle the
+#                 specific requirements for connecting to a console for that
+#                 environment.
+
+set -e
+
+cd "$(dirname "$0")/.."
+
+if [ -n "$1" ]; then
+  # use first argument as an environment name. Use this to decide how to connect
+  # to the appropriate console.
+  if [ "$1" = "production" ]; then
+    heroku run rails console --app heroku-app-name
+  elif [ "$1" = "staging" ]; then
+    heroku run rails console --app heroku-app-name-staging
+  else
+    echo "Sorry, I don't know how to connect to the '$1' environment."
+    exit 1
+  fi
+else
+  # no argument provided, so just run the local console in the development
+  # environment. Ensure the application is up to date first.
+  script/update
+  bin/rails console
+fi

--- a/script/server
+++ b/script/server
@@ -1,0 +1,18 @@
+#!/bin/sh
+
+# script/server: Launch the application and any extra required processes
+#                locally.
+
+set -e
+
+cd "$(dirname "$0")/.."
+
+# ensure everything in the app is up to date.
+script/update
+
+test -z "$RACK_ENV" &&
+  RACK_ENV='development'
+
+# boot the app and any other necessary processes.
+echo "If you need a DHIS2 instance, start one using Docker"
+foreman start -p 3000 --procfile=Procfile.dev

--- a/script/setup
+++ b/script/setup
@@ -1,0 +1,32 @@
+#!/bin/sh
+
+# script/setup: Set up application for the first time after cloning, or set it
+#               back to the initial first unused state.
+
+set -e
+
+cd "$(dirname "$0")/.."
+
+script/bootstrap
+
+if [ -f "config/database.yml" ] ; then
+    true
+else
+    echo "==> Generating config/database.yml"
+    cp config/database-template.yml.example config/database.yml
+fi
+
+echo "==> Setting up DB…"
+# reset database to a fresh state.
+bin/rake db:reset db:create
+
+if [ -z "$RAILS_ENV" ] && [ -z "$RACK_ENV" ]; then
+    # Only things for a development environment will run inside here
+    # Do things that need to be done to the application to set up for the first
+    # time. Or things needed to be run to to reset the application back to first
+    # use experience. These things are scoped to the application's domain.
+    echo "==> Seeding some default data…"
+    bin/rake db:seed
+fi
+
+echo "==> App is now ready to go!"

--- a/script/test
+++ b/script/test
@@ -1,0 +1,39 @@
+#!/bin/sh
+
+# script/test: Run test suite for application. Optionally pass in a path to an
+#              individual test file to run a single test.
+
+
+set -e
+
+cd "$(dirname "$0")/.."
+
+[ -z "$DEBUG" ] || set -x
+
+RACK_ROOT="$(cd "$(dirname "$0")"/.. && pwd)"
+export RACK_ROOT
+
+if [ "$RAILS_ENV" = "test" ] || [ "$RACK_ENV" = "test" ]; then
+  # if executed and the environment is already set to `test`, then we want a
+  # clean from scratch application. This almost always means a ci environment,
+  # since we set the environment to `test` directly in `script/cibuild`.
+  script/setup
+else
+  # if the environment isn't set to `test`, set it to `test` and update the
+  # application to ensure all dependencies are met as well as any other things
+  # that need to be up to date, like db migrations. The environment not having
+  # already been set to `test` almost always means this is being called on it's
+  # own from a `development` environment.
+  export RAILS_ENV="test" RACK_ENV="test"
+
+  script/update
+fi
+
+echo "==> Running tests…"
+
+if [ -n "$1" ]; then
+    # pass arguments to test call. This is useful for calling a single test.
+    bundle exec rspec "$1"
+else
+    bundle exec rspec --color
+fi

--- a/script/update
+++ b/script/update
@@ -1,0 +1,13 @@
+#!/bin/sh
+
+# script/update: Update application to run for its current checkout.
+
+set -e
+
+cd "$(dirname "$0")/.."
+
+script/bootstrap
+
+echo "==> Updating db…"
+# run all database migrations to ensure everything is up to date.
+bin/rake db:migrate

--- a/spec/lib/scorpio_spec.rb
+++ b/spec/lib/scorpio_spec.rb
@@ -1,0 +1,17 @@
+require "rails_helper"
+
+RSpec.describe Scorpio do
+  describe '.is_dev?' do
+    it 'returns true for development' do
+      expect(Rails.env).to receive(:development?) { true }
+      assert Scorpio.is_dev?, "Development is true"
+    end
+
+    it 'returns true for env variable' do
+      expect(Rails.env).to receive(:development?) { false }
+      ENV['ORBF_STAGING'] = "true"
+      assert Scorpio.is_dev?, "Flag found so should be true"
+      ENV.delete('ORBF_STAGING')
+    end
+  end
+end


### PR DESCRIPTION
This makes getting up and running, easier. It does this in a number of ways

## 1. Handy `/scripts`

These are modeled after https://github.com/github/scripts-to-rule-them-all, they provide a standard way across repos to:

- `script/bootstrap` (resolve dependencies)
- `script/setup` (setup entire project)
- `script/console` (get a console)
- `script/cibuild` (what ci calls)
- `script/test` (runs test)
- `script/update` (Updates your env to latest version)

So now a new user only needs to do `script/setup` and he should have everything needed to start working on orbf2

## 2. Improved review apps

Review apps now inherit the `DEFAULT_USER_EMAIL`, `ADMIN_PASSWORD` and `DEFAULT_USER_PASSWORD` from the staging application on Heroku. By default they're also set, but by inheriting them from the staging environment we limit access to the review apps to the same people that can access the staging environment.

I've also tried to update the env variables documentation a bit in the `app.json`

## 3. Better seeding

I've fixed the `setup/seeds` route, so now it can setup a project against the latest DHIS2 stable demo. I've also made it so that each new environment that gets seeded has a program and a user.

## Things I'd like a second opinion on

`lib/scorpio.rb`, I mainly use this file as a general place to put application wide configs or general utilities. At the moment, it only has the `is_dev?` method, I tend to have a method there as well to be able to send an error tot ErrorReportingService as well.

- Do we like the file?
- Do we like its name?
- Do we like that I disabled the rubocop rule? (I think the `is_` provides actual value here, it makes it a bit distinguished from `Rails.env.dev?`)

## Self proof reading checklist

- [x] Did I run Pronto and fixed all warnings
- [x] Make sure all naming and code will remain understandable in 6 month by someone new to the project or by you.
- [x] Did I test the right thing?
-  [x] Update documentation,readme accordingly