### PR TITLE
add category option combo support

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -529,4 +529,4 @@ RUBY VERSION
    ruby 2.5.1p57
 
 BUNDLED WITH
-   1.17.1
+   1.17.2

--- a/app/assets/javascripts/activities_controller.js
+++ b/app/assets/javascripts/activities_controller.js
@@ -1,0 +1,20 @@
+$(function() {
+  adapt_input_visibility = function() {
+    var action = this.value
+    var $inputs = $(this)
+      .parent()
+      .parent()
+      .find(".state-mapping-form");
+    $inputs.each(function() {
+      var $input = $(this);
+      if (action  == $input.data("action")) {
+        $input.show();
+      } else {
+        $input.hide();
+      }
+    });
+  };
+
+  $(".state-mapping-action").on("change", adapt_input_visibility);
+  $(".state-mapping-action").each(adapt_input_visibility);
+});

--- a/app/assets/javascripts/activities_controller.js
+++ b/app/assets/javascripts/activities_controller.js
@@ -7,7 +7,7 @@ $(function() {
       .find(".state-mapping-form");
     $inputs.each(function() {
       var $input = $(this);
-      if (action  == $input.data("action")) {
+      if (action  === $input.data("action")) {
         $input.show();
       } else {
         $input.hide();

--- a/app/controllers/setup/activities_controller.rb
+++ b/app/controllers/setup/activities_controller.rb
@@ -59,13 +59,7 @@ class Setup::ActivitiesController < PrivateController
   end
 
   def handle_action(template)
-    state_mapping = [
-      ["data_element", params[:data_elements]],
-      ["data_element_coc", params[:data_element_cocs]],
-      ["indicator", params[:indicators]]
-    ].detect do |state_mapping_action, elements|
-      params["state-mapping-action"] == state_mapping_action && elements
-    end
+    state_mapping = detect_state_mapping
     if state_mapping
       Activities::AddToActivityStates.new(
         project:  current_project,
@@ -83,6 +77,16 @@ class Setup::ActivitiesController < PrivateController
     end
 
     render template
+  end
+
+  def detect_state_mapping
+    [
+      ["data_element", params[:data_elements]],
+      ["data_element_coc", params[:data_element_cocs]],
+      ["indicator", params[:indicators]]
+    ].detect do |state_mapping_action, elements|
+      params["state-mapping-action"] == state_mapping_action && elements
+    end
   end
 
   def params_activity

--- a/app/models/activity_state.rb
+++ b/app/models/activity_state.rb
@@ -67,6 +67,14 @@ class ActivityState < ApplicationRecord
     kind == "data_element_coc"
   end
 
+  def data_element_related?
+    kind_data_element? || kind_data_element_coc?
+  end
+
+  def data_element_id
+    external_reference.split(".")[0]
+  end
+
   def to_unified_h
     {
       stable_id:          stable_id,

--- a/app/models/activity_state.rb
+++ b/app/models/activity_state.rb
@@ -40,7 +40,19 @@ class ActivityState < ApplicationRecord
   validates :name, presence: true
 
   validates :state_id, uniqueness: { scope: [:activity_id] }
-  KINDS = %w[data_element formula indicator data_element_coc].freeze
+
+  KIND_DATA_ELEMENT = "data_element"
+  KIND_INDICATOR = "indicator"
+  KIND_DATA_ELEMENT_COC = "data_element_coc"
+  KIND_FORMULA = "formula"
+
+  KINDS = [
+    KIND_DATA_ELEMENT,
+    KIND_FORMULA,
+    KIND_INDICATOR,
+    KIND_DATA_ELEMENT_COC
+  ].freeze
+
   validates :kind, inclusion: {
     in:      KINDS,
     message: "%{value} is not a valid see #{KINDS.join(',')}"
@@ -52,19 +64,19 @@ class ActivityState < ApplicationRecord
   end
 
   def kind_data_element?
-    kind == "data_element"
+    kind == KIND_DATA_ELEMENT
   end
 
   def kind_formula?
-    kind == "formula"
+    kind == KIND_FORMULA
   end
 
   def kind_indicator?
-    kind == "indicator"
+    kind == KIND_INDICATOR
   end
 
   def kind_data_element_coc?
-    kind == "data_element_coc"
+    kind == KIND_DATA_ELEMENT_COC
   end
 
   def data_element_related?

--- a/app/models/activity_state.rb
+++ b/app/models/activity_state.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # == Schema Information
 #
 # Table name: activity_states
@@ -38,6 +40,11 @@ class ActivityState < ApplicationRecord
   validates :name, presence: true
 
   validates :state_id, uniqueness: { scope: [:activity_id] }
+  KINDS = %w[data_element formula indicator data_element_coc].freeze
+  validates :kind, inclusion: {
+    in:      KINDS,
+    message: "%{value} is not a valid see #{KINDS.join(',')}"
+  }
 
   def external_reference=(external_reference)
     external_reference = nil if external_reference.blank?
@@ -54,6 +61,10 @@ class ActivityState < ApplicationRecord
 
   def kind_indicator?
     kind == "indicator"
+  end
+
+  def kind_data_element_coc?
+    kind == "data_element_coc"
   end
 
   def to_unified_h

--- a/app/services/activities/add_to_activity_states.rb
+++ b/app/services/activities/add_to_activity_states.rb
@@ -1,66 +1,67 @@
 # frozen_string_literal: true
 
-class Activities::AddToActivityStates
-  attr_reader :project, :activity, :elements, :kind, :existing_element_ids, :selectable_element_ids
+module Activities
+  class AddToActivityStates
+    attr_reader :project, :activity, :elements, :kind, :existing_element_ids, :selectable_element_ids
 
-  def initialize(project:, activity:, elements:, kind:)
-    @project = project
-    @activity = activity
-    byebug
-    @elements = elements || []
-    @kind = kind
-    @existing_element_ids = activity.activity_states
-                                    .select { |as| as.kind == kind }
-                                    .map(&:external_reference)
-    @selectable_element_ids = @elements - existing_element_ids
-  end
-
-  def call
-    elements_to_build.each do |element|
-      @activity.activity_states.build(
-        external_reference: element.id,
-        name:               element.name,
-        kind:               kind
-      )
+    def initialize(project:, activity:, elements:, kind:)
+      @project = project
+      @activity = activity
+      @elements = elements || []
+      @kind = kind
+      @existing_element_ids = activity.activity_states
+                                      .select { |as| as.kind == kind }
+                                      .map(&:external_reference)
+      @selectable_element_ids = @elements - existing_element_ids
     end
-  end
 
-  def elements_to_build
-    if kind == "data_element_coc"
-      elements_to_build_data_elements_cocs
-    elsif kind == "indicator"
-      elements_to_build_indicators
-    elsif kind == "data_element"
-      elements_to_build_data_elements
-    else
-      raise "unsupported kind : #{kind}"
-    end
-  end
-
-  def elements_to_build_indicators
-    data_compound = DataCompound.from(project)
-    selectable_element_ids.map { |element_id| data_compound.indicator(element_id) }
-  end
-
-  def elements_to_build_data_elements
-    data_compound = DataCompound.from(project)
-    selectable_element_ids.map { |element_id| data_compound.data_element(element_id) }
-  end
-
-  def elements_to_build_data_elements_cocs
-    data_elements_with_coc = project.dhis2_connection.data_elements.list(
-      filter: "id:in:[" + elements.join(",") + "]",
-      fields: "id,name,categoryCombo[id,name,categoryOptionCombos[id,name]]"
-    )
-    data_elements_with_coc.each_with_object([]) do |de, results|
-      de.category_combo["category_option_combos"].each do |coc|
-        composite_id = de.id + "." + coc["id"]
-        next if existing_element_ids.include?(composite_id)
-
-        results << OpenStruct.new(
-          id:   composite_id,
-          name: de.name + " - " + coc["name"]
+    def call
+      elements_to_build.each do |element|
+        @activity.activity_states.build(
+          external_reference: element.id,
+          name:               element.name,
+          kind:               kind
         )
+      end
+    end
+
+    def elements_to_build
+      if kind == "data_element_coc"
+        elements_to_build_data_element_cocs
+      elsif kind == "indicator"
+        elements_to_build_indicators
+      elsif kind == "data_element"
+        elements_to_build_data_elements
+      else
+        raise "unsupported kind : #{kind}"
+      end
+    end
+
+    def elements_to_build_indicators
+      data_compound = DataCompound.from(project)
+      selectable_element_ids.map { |element_id| data_compound.indicator(element_id) }
+    end
+
+    def elements_to_build_data_elements
+      data_compound = DataCompound.from(project)
+      selectable_element_ids.map { |element_id| data_compound.data_element(element_id) }
+    end
+
+    def elements_to_build_data_element_cocs
+      data_elements_with_coc = project.dhis2_connection.data_elements.list(
+        filter: "id:in:[" + elements.join(",") + "]",
+        fields: "id,name,categoryCombo[id,name,categoryOptionCombos[id,name]]"
+      )
+      data_elements_with_coc.each_with_object([]) do |de, results|
+        de.category_combo["category_option_combos"].each do |coc|
+          composite_id = de.id + "." + coc["id"]
+          next if existing_element_ids.include?(composite_id)
+
+          results << OpenStruct.new(
+            id:   composite_id,
+            name: de.name + " - " + coc["name"]
+          )
+        end
       end
     end
   end

--- a/app/services/activities/add_to_activity_states.rb
+++ b/app/services/activities/add_to_activity_states.rb
@@ -1,6 +1,14 @@
 # frozen_string_literal: true
 
 module Activities
+  class DataElementInfo
+    attr_reader :id, :name
+    def initialize(infos)
+      @id = infos.fetch(:id)
+      @name = infos.fetch(:name)
+    end
+  end
+
   class AddToActivityStates
     attr_reader :project, :activity, :elements, :kind,
                 :existing_element_ids, :selectable_element_ids
@@ -54,7 +62,7 @@ module Activities
           composite_id = de.id + "." + coc["id"]
           next if existing_element_ids.include?(composite_id)
 
-          results << OpenStruct.new(
+          results << DataElementInfo.new(
             id:   composite_id,
             name: de.name + " - " + coc["name"]
           )

--- a/app/services/activities/add_to_activity_states.rb
+++ b/app/services/activities/add_to_activity_states.rb
@@ -1,0 +1,67 @@
+# frozen_string_literal: true
+
+class Activities::AddToActivityStates
+  attr_reader :project, :activity, :elements, :kind, :existing_element_ids, :selectable_element_ids
+
+  def initialize(project:, activity:, elements:, kind:)
+    @project = project
+    @activity = activity
+    byebug
+    @elements = elements || []
+    @kind = kind
+    @existing_element_ids = activity.activity_states
+                                    .select { |as| as.kind == kind }
+                                    .map(&:external_reference)
+    @selectable_element_ids = @elements - existing_element_ids
+  end
+
+  def call
+    elements_to_build.each do |element|
+      @activity.activity_states.build(
+        external_reference: element.id,
+        name:               element.name,
+        kind:               kind
+      )
+    end
+  end
+
+  def elements_to_build
+    if kind == "data_element_coc"
+      elements_to_build_data_elements_cocs
+    elsif kind == "indicator"
+      elements_to_build_indicators
+    elsif kind == "data_element"
+      elements_to_build_data_elements
+    else
+      raise "unsupported kind : #{kind}"
+    end
+  end
+
+  def elements_to_build_indicators
+    data_compound = DataCompound.from(project)
+    selectable_element_ids.map { |element_id| data_compound.indicator(element_id) }
+  end
+
+  def elements_to_build_data_elements
+    data_compound = DataCompound.from(project)
+    selectable_element_ids.map { |element_id| data_compound.data_element(element_id) }
+  end
+
+  def elements_to_build_data_elements_cocs
+    data_elements_with_coc = project.dhis2_connection.data_elements.list(
+      filter: "id:in:[" + elements.join(",") + "]",
+      fields: "id,name,categoryCombo[id,name,categoryOptionCombos[id,name]]"
+    )
+    data_elements_with_coc.each_with_object([]) do |de, results|
+      de.category_combo["category_option_combos"].each do |coc|
+        composite_id = de.id + "." + coc["id"]
+        next if existing_element_ids.include?(composite_id)
+
+        results << OpenStruct.new(
+          id:   composite_id,
+          name: de.name + " - " + coc["name"]
+        )
+      end
+    end
+  end
+end

--- a/app/services/activities/add_to_activity_states.rb
+++ b/app/services/activities/add_to_activity_states.rb
@@ -2,7 +2,8 @@
 
 module Activities
   class AddToActivityStates
-    attr_reader :project, :activity, :elements, :kind, :existing_element_ids, :selectable_element_ids
+    attr_reader :project, :activity, :elements, :kind,
+                :existing_element_ids, :selectable_element_ids
 
     def initialize(project:, activity:, elements:, kind:)
       @project = project
@@ -48,11 +49,7 @@ module Activities
     end
 
     def elements_to_build_data_element_cocs
-      data_elements_with_coc = project.dhis2_connection.data_elements.list(
-        filter: "id:in:[" + elements.join(",") + "]",
-        fields: "id,name,categoryCombo[id,name,categoryOptionCombos[id,name]]"
-      )
-      data_elements_with_coc.each_with_object([]) do |de, results|
+      data_elements_with_coc(elements).each_with_object([]) do |de, results|
         de.category_combo["category_option_combos"].each do |coc|
           composite_id = de.id + "." + coc["id"]
           next if existing_element_ids.include?(composite_id)
@@ -63,6 +60,13 @@ module Activities
           )
         end
       end
+    end
+
+    def data_elements_with_coc(elements)
+      project.dhis2_connection.data_elements.list(
+        filter: "id:in:[" + elements.join(",") + "]",
+        fields: "id,name,categoryCombo[id,name,categoryOptionCombos[id,name]]"
+      )
     end
   end
 end

--- a/app/services/map_project_to_orbf_project.rb
+++ b/app/services/map_project_to_orbf_project.rb
@@ -74,7 +74,8 @@ class MapProjectToOrbfProject
     activity_states.select { |activity_state| package_states.include?(activity_state.state) }
                    .map do |activity_state|
       kind = ACTIVITY_STATE_KIND[activity_state.kind] || activity_state.kind
-      formula = activity_state.formula || dhis2_indicators_by_id[activity_state.external_reference]&.numerator
+      formula = activity_state.formula ||
+                dhis2_indicators_by_id[activity_state.external_reference]&.numerator
       ext_id = activity_state.external_reference
       if activity_state.kind_data_element_coc?
         # fake date_element_coc as indicator

--- a/app/services/map_project_to_orbf_project.rb
+++ b/app/services/map_project_to_orbf_project.rb
@@ -38,6 +38,7 @@ class MapProjectToOrbfProject
     @cache_package ||= {}
     from_cache = @cache_package[package]
     return from_cache if from_cache
+
     @cache_package[package] = Orbf::RulesEngine::Package.new(
       code:                          package.code,
       kind:                          PACKAGE_KINDS[package.kind] || package.kind,
@@ -72,12 +73,22 @@ class MapProjectToOrbfProject
   def map_activity_states(activity_states, package_states)
     activity_states.select { |activity_state| package_states.include?(activity_state.state) }
                    .map do |activity_state|
+      kind = ACTIVITY_STATE_KIND[activity_state.kind] || activity_state.kind
+      formula = activity_state.formula || dhis2_indicators_by_id[activity_state.external_reference]&.numerator
+      ext_id = activity_state.external_reference
+      if activity_state.kind_data_element_coc?
+        # fake date_element_coc as indicator
+        kind = "indicator"
+        formula = '#{' + activity_state.external_reference + "}"
+        ext_id = "inlined-"+ext_id
+      end
+      #byebug if activity_state.kind_indicator?
       Orbf::RulesEngine::ActivityState.with(
         state:   activity_state.state.code,
         name:    activity_state.name,
-        formula: activity_state.formula || dhis2_indicators_by_id[activity_state.external_reference]&.numerator,
-        kind:    ACTIVITY_STATE_KIND[activity_state.kind] || activity_state.kind,
-        ext_id:  activity_state.external_reference
+        formula: formula,
+        kind:    kind,
+        ext_id:  ext_id
       )
     end
   end

--- a/app/services/map_project_to_orbf_project.rb
+++ b/app/services/map_project_to_orbf_project.rb
@@ -80,9 +80,8 @@ class MapProjectToOrbfProject
         # fake date_element_coc as indicator
         kind = "indicator"
         formula = '#{' + activity_state.external_reference + "}"
-        ext_id = "inlined-"+ext_id
+        ext_id = "inlined-" + ext_id
       end
-      #byebug if activity_state.kind_indicator?
       Orbf::RulesEngine::ActivityState.with(
         state:   activity_state.state.code,
         name:    activity_state.name,

--- a/app/views/setup/activities/_constant.html.erb
+++ b/app/views/setup/activities/_constant.html.erb
@@ -1,6 +1,6 @@
 
 <tr>
-  <td width="50%"><%= f.input :name%></td>
+  <td width="50%"><%= f.input :name,  input_html: {value: f.object.name || @activity.name} %></td>
   <td><%= f.input :state_id , collection: states.where(level: "activity")%></td>
   <td><%= f.input :formula %></td>
   <%= f.hidden_field :kind, value: 'formula' %>

--- a/app/views/setup/activities/_constant.html.erb
+++ b/app/views/setup/activities/_constant.html.erb
@@ -1,6 +1,6 @@
 
 <tr>
-  <td><%= f.input :name%></td>
+  <td width="50%"><%= f.input :name%></td>
   <td><%= f.input :state_id , collection: states.where(level: "activity")%></td>
   <td><%= f.input :formula %></td>
   <%= f.hidden_field :kind, value: 'formula' %>

--- a/app/views/setup/activities/_form.html.erb
+++ b/app/views/setup/activities/_form.html.erb
@@ -133,4 +133,7 @@ If they don't exist yet in dhis2, you can create them via this <%= link_to "page
   <br><br>
 <% end %>
 <%= f.button :submit, class: "btn btn-success" %>
-<%= link_to "Cancel and back to setup", root_path(activity.project) ,class: "btn btn-default"%>
+<%= link_to "Cancel and back to setup", root_path(activity.project, anchor: "step-activities") ,class: "btn btn-default"%>
+  <br><br>
+    <br><br>
+      <br><br>

--- a/app/views/setup/activities/_form.html.erb
+++ b/app/views/setup/activities/_form.html.erb
@@ -37,7 +37,7 @@ If they don't exist yet in dhis2, you can create them via this <%= link_to "page
     <div class="col-md-6 " >
         <div class="form-group">
           <label class="control-label">Data Elements</label>
-          <select id="data_elementcocs_selector" data-selected="<%=params[:data_element_coc].join(',') if params[:data_element_coc] %>"
+          <select id="data_elementcocs_selector" data-selected=""
                 data-placeholder="Lookup the data elements here..."
                 data-selection = "data_elementcocs_selection"
                 data-url = "<%= data_elements_setup_project_autocomplete_index_path(@activity.project) %>"
@@ -61,7 +61,14 @@ If they don't exist yet in dhis2, you can create them via this <%= link_to "page
     <div class="col-md-6 " >
         <div class="form-group">
           <label class="control-label">Data Elements</label>
-          <select id="data_elements_selector" data-selected="<%=params[:data_elements].join(',') if params[:data_elements] %>" data-placeholder="Lookup the data elements here..." data-selection = "data_elements_selection" data-url = "<%= data_elements_setup_project_autocomplete_index_path(@activity.project) %>" class="form-control sol-powered" name="data_elements[]" multiple="multiple">
+          <select id="data_elements_selector"
+                  data-selected=""
+                  data-placeholder="Lookup the data elements here..."
+                  data-selection = "data_elements_selection"
+                  data-url = "<%= data_elements_setup_project_autocomplete_index_path(@activity.project) %>"
+                  class="form-control sol-powered"
+                  name="data_elements[]"
+                  multiple="multiple">
           </select>
         </div>
     </div>
@@ -82,7 +89,12 @@ If they don't exist yet in dhis2, you can create them via this <%= link_to "page
     <div class="col-md-6">
       <div class="form-group">
         <label class="control-label">Indicators</label>
-        <select id="indicators_selector" data-selected="<%=params[:indicators].join(',') if params[:indicators] %>" data-placeholder="Lookup the indicators here..." data-selection = "indicators_selection" data-url = "<%= indicators_setup_project_autocomplete_index_path(@activity.project) %>" class="form-control sol-powered" name="indicators[]" multiple="multiple">
+        <select id="indicators_selector"
+                data-selected=""
+                data-placeholder="Lookup the indicators here..."
+                data-selection = "indicators_selection"
+                data-url = "<%= indicators_setup_project_autocomplete_index_path(@activity.project) %>"
+                class="form-control sol-powered" name="indicators[]" multiple="multiple">
         </select>
     </div>
 

--- a/app/views/setup/activities/_form.html.erb
+++ b/app/views/setup/activities/_form.html.erb
@@ -21,43 +21,88 @@ If they don't exist yet in dhis2, you can create them via this <%= link_to "page
 </p>
 <%end%>
 <hr>
-<div class="row">
-    <div class="col-md-6">
-      <div class="form-group">
-        <label class="control-label">Data Elements</label>
-        <select id="data_elements_selector" data-selected="<%=params[:data_elements].join(',') if params[:data_elements] %>" data-placeholder="Lookup the data elements here..." data-selection = "data_elements_selection" data-url = "<%= data_elements_setup_project_autocomplete_index_path(@activity.project) %>" class="form-control sol-powered" name="data_elements[]" multiple="multiple">
-        </select>
+<h2>Add dhis2 data for state mappings</h2>
+  <select class="state-mapping-action form-control" name="state-mapping-action">
+    <%= options_for_select([
+        ["Add data elements", "data_element"],
+        ["Add data elements with category option combo", "data_element_coc"],
+        ["Add indicators", "indicator"],
+        ["Add constants", "constant"]
+      ], params["state-mapping-action"] || "data_element") %>
+  </select>
+<ul>
+<br>
+<div class="state-mapping-form" data-action="data_element_coc">
+   <div class="row">
+    <div class="col-md-6 " >
+        <div class="form-group">
+          <label class="control-label">Data Elements</label>
+          <select id="data_elementcocs_selector" data-selected="<%=params[:data_element_coc].join(',') if params[:data_element_coc] %>"
+                data-placeholder="Lookup the data elements here..."
+                data-selection = "data_elementcocs_selection"
+                data-url = "<%= data_elements_setup_project_autocomplete_index_path(@activity.project) %>"
+                class="form-control sol-powered" name="data_element_cocs[]" multiple="multiple">
+          </select>
+        </div>
     </div>
-  </div>
-  <div class="col-md-6">
-     <div class="col-md-12" id="data_elements_selection"></div>
-     <div class="pull-right">
-      <%= f.button :submit, 'Add data elements for state mapping', class: "btn btn-primary" %>
+    <div class="col-md-6">
+     <div class="col-md-12" id="data_elementcocs_selection"></div>
+    </div>
+   </div>
+   <div class="col-md-6">
+     <div >
+      <%= f.button :submit, 'Add for state mapping', class: "btn btn-primary" %>
     </div>
   </div>
 </div>
-<hr>
 
-<div class="row">
+<div class="state-mapping-form" data-action="data_element">
+   <div class="row">
+    <div class="col-md-6 " >
+        <div class="form-group">
+          <label class="control-label">Data Elements</label>
+          <select id="data_elements_selector" data-selected="<%=params[:data_elements].join(',') if params[:data_elements] %>" data-placeholder="Lookup the data elements here..." data-selection = "data_elements_selection" data-url = "<%= data_elements_setup_project_autocomplete_index_path(@activity.project) %>" class="form-control sol-powered" name="data_elements[]" multiple="multiple">
+          </select>
+        </div>
+    </div>
+    <div class="col-md-6">
+     <div class="col-md-12" id="data_elements_selection"></div>
+    </div>
+   </div>
+   <div class="col-md-6">
+     <div class="col-md-12" id="data_elements_selection"></div>
+     <div >
+      <%= f.button :submit, 'Add for state mapping', class: "btn btn-primary" %>
+    </div>
+  </div>
+</div>
+
+
+<div class="row state-mapping-form" data-action="indicator">
     <div class="col-md-6">
       <div class="form-group">
         <label class="control-label">Indicators</label>
         <select id="indicators_selector" data-selected="<%=params[:indicators].join(',') if params[:indicators] %>" data-placeholder="Lookup the indicators here..." data-selection = "indicators_selection" data-url = "<%= indicators_setup_project_autocomplete_index_path(@activity.project) %>" class="form-control sol-powered" name="indicators[]" multiple="multiple">
         </select>
     </div>
-  </div>
-  <div class="col-md-6">
+
      <div class="col-md-12" id="indicators_selection"></div>
-     <div class="pull-right">
+     <div >
       <%= f.button :submit, 'Add indicators for state mapping', class: "btn btn-primary" %>
     </div>
   </div>
 </div>
 
+<div class="row state-mapping-form" data-action="constant">
+    <%= link_to_add_association 'Add a constant', f, :activity_states, partial: 'constant',class: "btn btn-secondary" %>
+    <%= f.button :submit, 'Add for state mapping', class: "btn btn-primary" %>
+</div>
+</ul>
+<br>
 <hr>
 
 <% if params.has_key?(:activity) || activity.activity_states.present? %>
-
+<h2>Map data to state</h2>
 <div>
     <table class="table table-striped table-condensed">
         <thead>
@@ -77,7 +122,6 @@ If they don't exist yet in dhis2, you can create them via this <%= link_to "page
                prefix:  "activity[activity_states_attributes][#{activity_state_form.index}]"
                } %>
           <% end %>
-          <%= link_to_add_association 'Add constant', f, :activity_states, partial: 'constant',class: "btn btn-primary pull-right" %>
         </body>
     </table>
 </div>

--- a/spec/controllers/setup/activities_controller_spec.rb
+++ b/spec/controllers/setup/activities_controller_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe Setup::ActivitiesController, type: :controller do
       expect(activity).not_to be_nil
     end
 
-    it "should return form for creation of a new activity" do
+    it "should return form for edition of a new activity" do
       get :edit, params: { project_id: project.id, id: project.activities.first.id }
       activity = assigns(:activity)
       states = assigns(:states)

--- a/spec/controllers/setup/activities_controller_spec.rb
+++ b/spec/controllers/setup/activities_controller_spec.rb
@@ -174,7 +174,7 @@ RSpec.describe Setup::ActivitiesController, type: :controller do
             name: "indicator name from dhis2"
           }]
         }.to_json)
-    end
+      end
     end
 
     describe "#create" do
@@ -280,6 +280,7 @@ RSpec.describe Setup::ActivitiesController, type: :controller do
                }.from(activity: 2, activity_states: 4)
           .to(activity: 3, activity_states: 5)
       end
+
       def create_activity_with_code_and_data_element
         post :create, params: {
           project_id: project.id,

--- a/spec/controllers/setup/activities_controller_spec.rb
+++ b/spec/controllers/setup/activities_controller_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "rails_helper"
 
 RSpec.describe Setup::ActivitiesController, type: :controller do
@@ -92,6 +94,87 @@ RSpec.describe Setup::ActivitiesController, type: :controller do
                      }
                    }
       end
+
+      it "should add data elements with category option combo to activity states" do
+        stub_request(:get, "http://play.dhis2.org/demo/api/dataElements?fields=id,name,categoryCombo%5Bid,name,categoryOptionCombos%5Bid,name%5D%5D&filter=id:in:%5BP3jJH5Tu5VC%5D")
+          .to_return(status: 200, body: { "dataElements": [
+            { "name" => "Acute Flaccid Paralysis (AFP) follow-up",
+              "id" => "P3jJH5Tu5VC",
+              "categoryCombo": { "name"                 => "Morbidity Age",
+                                 "id"                   => "pbvcDRasDav",
+                                 "categoryOptionCombos" => [
+                                   { "name" => "15y+", "id" => "tMwM3ZBd7BN" },
+                                   { "name" => "0-11m", "id" => "sqGRzCziswD" },
+                                   { "name" => "12-59m", "id" => "wHBMVthqIX4" },
+                                   { "name" => "5-14y", "id" => "b7fjZVL3q9b" }
+                                 ] } }
+          ] }.to_json)
+
+        post :update, params: {
+          project_id: project.id,
+          id:         project.activities.first.id,
+          activity: { name: "demo" },
+          "state-mapping-action" =>   "data_element_coc",
+          data_element_cocs: ["P3jJH5Tu5VC"]
+        }
+
+        expect(activity_state_added.name).to eq("Acute Flaccid Paralysis (AFP) follow-up - 5-14y")
+        expect(activity_state_added.external_reference).to eq("P3jJH5Tu5VC.b7fjZVL3q9b")
+        expect(activity_state_added.id).to be_nil
+      end
+
+      it "should add data elements to activity states" do
+        stub_data_compound
+        post :update, params: {
+          project_id: project.id,
+          id:         project.activities.first.id,
+          activity: { name: "demo" },
+          "state-mapping-action" =>   "data_element",
+          data_elements: ["deid"]
+        }
+        expect_last_state_added("deid", "de name from dhis2")
+      end
+
+      it "should add indicators to activity states" do
+        stub_data_compound
+        post :update, params: {
+          project_id: project.id,
+          id:         project.activities.first.id,
+          activity: { name: "demo" },
+          "state-mapping-action" =>   "indicator",
+          indicators: ["indicatorid"]
+        }
+        expect_last_state_added("indicatorid", "indicator name from dhis2")
+      end
+
+      def activity_state_added
+        assigns[:activity].activity_states.last
+      end
+
+      def expect_last_state_added(external_reference, name)
+        expect(activity_state_added.name).to eq(name)
+        expect(activity_state_added.external_reference).to eq(external_reference)
+        expect(activity_state_added.id).to be_nil
+      end
+
+      def stub_data_compound
+        stub_request(:get, "http://play.dhis2.org/demo/api/dataElements?fields=:all&pageSize=5000")
+          .to_return(status: 200, body: {
+            dataElements: [{
+              id:   "deid",
+              name: "de name from dhis2"
+            }]
+          }.to_json)
+        stub_request(:get, "http://play.dhis2.org/demo/api/dataElementGroups?fields=:all&pageSize=5000").to_return(status: 200, body: {
+          dataElementGroups: []
+        }.to_json)
+        stub_request(:get, "http://play.dhis2.org/demo/api/indicators?fields=:all&pageSize=5000").to_return(status: 200, body: {
+          indicators: [{
+            id:   "indicatorid",
+            name: "indicator name from dhis2"
+          }]
+        }.to_json)
+    end
     end
 
     describe "#create" do

--- a/spec/models/activity_spec.rb
+++ b/spec/models/activity_spec.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 # == Schema Information
 #
 # Table name: activities
@@ -42,6 +43,7 @@ RSpec.describe Activity, type: :model do
                    }
                  ])
   end
+
   it "should be valid by default" do
     expect(activity.valid?).to be true
   end
@@ -56,5 +58,28 @@ RSpec.describe Activity, type: :model do
     activity.valid?
     expect(activity.errors.full_messages).to eq(["Code : should only contains lowercase letters and _ like 'assisted_deliveries' or 'vaccination_under_one_year' vs #{activity.code}"])
     expect(activity.valid?).to be false
+  end
+
+  it "should allow getting data_element_id" do
+    expect(activity.activity_states.first.data_element_id).to eq("external_reference")
+  end
+
+  describe "with activity states de_coc" do
+    let(:activity_de_coc) do
+      Activity.new(name:                       "activity_name",
+                   code:                       "activity_code",
+                   project:                    project,
+                   activity_states_attributes: [
+                     {
+                       name:               "activity_state_name",
+                       external_reference: "external_reference.coc_id",
+                       kind:               "data_element_coc",
+                       state_id:           project.states.first.id
+                     }
+                   ])
+    end
+    it "should allow getting data_element_id" do
+      expect(activity_de_coc.activity_states.first.data_element_id).to eq("external_reference")
+    end
   end
 end


### PR DESCRIPTION
allow to add data elements with category options as activity state.

![image](https://user-images.githubusercontent.com/371692/51041292-e2d12080-15b9-11e9-865a-c08fe54afce0.png)

for the rules engine, they will behave like indicators
the synchronisation of data element/data element group

I know that some part of the ui is not 100% ok (eg metadata, simulation page )
but we should probably start configuring the SIGL project beginning next week.

