### PR TITLE
Capture and verify process

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,7 +24,7 @@ public/coverage
 dump.rdb
 .byebug_history
 coverage
-
+spec/artefacts/*
 # I, pj, still vendor my ruby gems in the directory of the
 # application, this stops me from committing them here.
 vendor/ruby

--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,8 @@ dump.rdb
 .byebug_history
 coverage
 spec/artefacts/*
+config/data_test.json
+
 # I, pj, still vendor my ruby gems in the directory of the
 # application, this stops me from committing them here.
 vendor/ruby

--- a/Gemfile
+++ b/Gemfile
@@ -89,7 +89,10 @@ group :development, :test do
   gem "ruby-prof"
   gem "shoulda-matchers", require: false
 
+  gem "aws-sdk-s3", "~> 1.30.1"
   gem "capybara", "~> 3.12.0"
+  gem "json-diff", "~> 0.4.1"
+  gem "rubyzip", "~> 1.2.2"
   gem "selenium-webdriver", "~> 3.141.0"
 end
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -84,6 +84,21 @@ GEM
     ast (2.4.0)
     autoprefixer-rails (9.4.2)
       execjs
+    aws-eventstream (1.0.1)
+    aws-partitions (1.136.0)
+    aws-sdk-core (3.46.0)
+      aws-eventstream (~> 1.0)
+      aws-partitions (~> 1.0)
+      aws-sigv4 (~> 1.0)
+      jmespath (~> 1.0)
+    aws-sdk-kms (1.13.0)
+      aws-sdk-core (~> 3, >= 3.39.0)
+      aws-sigv4 (~> 1.0)
+    aws-sdk-s3 (1.30.1)
+      aws-sdk-core (~> 3, >= 3.39.0)
+      aws-sdk-kms (~> 1)
+      aws-sigv4 (~> 1.0)
+    aws-sigv4 (1.0.3)
     bcrypt (3.1.12)
     bindex (0.5.0)
     bootsnap (1.3.2)
@@ -185,6 +200,7 @@ GEM
     jbuilder (2.8.0)
       activesupport (>= 4.2.0)
       multi_json (>= 1.2)
+    jmespath (1.4.0)
     jquery-rails (4.3.3)
       rails-dom-testing (>= 1, < 3)
       railties (>= 4.2.0)
@@ -192,6 +208,7 @@ GEM
     jquery-ui-rails (5.0.5)
       railties (>= 3.2.16)
     json (2.1.0)
+    json-diff (0.4.1)
     kaminari (1.1.1)
       activesupport (>= 4.1.0)
       kaminari-actionview (= 1.1.1)
@@ -478,6 +495,7 @@ PLATFORMS
 
 DEPENDENCIES
   annotate (~> 2.7.4)
+  aws-sdk-s3 (~> 1.30.1)
   bootsnap (~> 1.3.2)
   bootstrap-datepicker-rails
   bootstrap-sass (~> 3.3.6)
@@ -505,6 +523,7 @@ DEPENDENCIES
   jquery-rails (~> 4.3.3)
   jquery-ui-rails (~> 5.0.5)
   json (= 2.1.0)
+  json-diff (~> 0.4.1)
   listen (~> 3.0.5)
   lograge (~> 0.10.0)
   loofah (>= 2.2.3)
@@ -531,6 +550,7 @@ DEPENDENCIES
   rspec-sidekiq
   rubocop
   ruby-prof
+  rubyzip (~> 1.2.2)
   sassc-rails (~> 2.0.0)
   selenium-webdriver (~> 3.141.0)
   sentry-raven (~> 2.7.4)

--- a/app/models/invoicing_request.rb
+++ b/app/models/invoicing_request.rb
@@ -2,9 +2,15 @@ class InvoicingRequest
   include ActiveModel::Model
   include ActiveModel::Validations
 
-  attr_accessor :entity, :year, :quarter, :project, :invoices, :mock_values, :engine_version, :with_details
+  attr_accessor :entity, :year, :quarter, :project, :invoices, :mock_values, :engine_version, :with_details, :mocked_data
 
   validates :entity, presence: true
+
+  def initialize(*)
+    super
+    @mocked_data ||= [] if mock_values?
+  end
+
 
   def start_date_as_date
     year_quarter.start_date

--- a/app/services/invoicing/invoice_entity.rb
+++ b/app/services/invoicing/invoice_entity.rb
@@ -44,7 +44,7 @@ module Invoicing
       @fetch_and_solve ||= begin
           solve_options = {
             pyramid:     pyramid,
-            mock_values: invoicing_request.mock_values? ? [] : nil
+            mock_values: invoicing_request.mocked_data
           }
           @fetch_and_solve = Orbf::RulesEngine::FetchAndSolve.new(
             orbf_project,

--- a/doc/capture-and-verify-process.md
+++ b/doc/capture-and-verify-process.md
@@ -1,0 +1,74 @@
+## Objective
+
+We want an automated, reliable check to see if adjustments made to:
+
+- hesabu
+- hesabu-go
+- orbf-rules_engine
+- orbf2
+
+Have an impact on previously made calculations.
+
+In order to do this we've identified several projects and org units that we want to check by using production data and comparing the results to a newer version.
+
+## High level overview
+
+- Capture phase
+- Verify phase
+
+### Capture Phase
+
+Take a snapshot of current production data, load it locally and execute a command to capture all the data needed to generate an invoice. The end goal is to have a set of data that:
+
+- Works independently of DHIS2 availability
+- Works without access to production database
+
+This will run with the code as it was last deployed in production, these results should be captured but should never be committed to the repository (since they might contain sensitive production data).
+
+### Verify Phase
+
+With new code, like in a feature-branch, load a simulation with the data of the capture phase and compare the results against the results of the capture phase. This should work without access to DHIS2 or access to the production database.
+
+## How to store capture phase data?
+
+Since capture phase data should be treated as sensitive data, it should never be committed to the repo. Instead the results of the capure phase should be uploaded to a protected S3 bucket. The verify phase could use env variables to be able to download the results and then run against those files.
+
+Currently these artefacts are generated:
+
+Data to inflate to a known situation:
+
+- `<name>-<orgunit>-data-compound.yml` (a YAML serialization of `DataCompound`)
+- `<name>-<orgunit>-project.yml` (a YAML serialization of a `Project`)
+- `<name>-<orgunit>-pyramid.yml` (a YAML serialization of the complete pyramid)
+- `<name>-<orgunit>-input-values.json` (a JSON containing all DHIS2-input values)
+
+Results:
+
+- `<name>-<orgunit>-problem.json` (a JSON containing the problem that will be sent to hesabu)
+- `<name>-<orgunit>-solution.json` (a JSON containing the solution coming out of hesabu)
+- `<name>-<orgunit>-exported_values.json` (a JSON containing all values that would be exported)
+
+Things we are looking for:
+
+- Data should be versioned
+- Data should be protected
+- Data should be retrievable
+
+What I'd propose is to have the capture phase (on a successfull run):
+
+- upload the individual files to S3
+- Have the S3 bucket be setup to be versioned
+- Zip all the files and upload to S3 (for easier access)
+
+On a verify phase the ENV will be checked for the URL of the zip:
+
+- Zip would be downloaded and extracted
+- Verify phase would run against those files
+- Verify phase gets run on CI and results are displayed there (careful about leaking data in a public CI)
+
+Todos:
+
+- [ ] 1 command to start a capture phase
+- [ ] 1 command to upload capture artefacts to S3
+- [ ] Verify phase gets added to rspec run
+- [ ] Verify phase can use uploaded data

--- a/doc/capture-and-verify-process.md
+++ b/doc/capture-and-verify-process.md
@@ -11,6 +11,16 @@ Have an impact on previously made calculations.
 
 In order to do this we've identified several projects and org units that we want to check by using production data and comparing the results to a newer version.
 
+## How to run?
+
+Capturing can be done by running:
+
+      DB_NAME=<production-copy> bundle exec rake data_test:capture_and_upload
+
+Verifying can be run (and is run by CI) with:
+
+      bundle exec rake spec:data_test
+
 ## High level overview
 
 - Capture phase
@@ -50,25 +60,6 @@ Results:
 
 Things we are looking for:
 
-- Data should be versioned
-- Data should be protected
-- Data should be retrievable
-
-What I'd propose is to have the capture phase (on a successfull run):
-
-- upload the individual files to S3
-- Have the S3 bucket be setup to be versioned
-- Zip all the files and upload to S3 (for easier access)
-
-On a verify phase the ENV will be checked for the URL of the zip:
-
-- Zip would be downloaded and extracted
-- Verify phase would run against those files
-- Verify phase gets run on CI and results are displayed there (careful about leaking data in a public CI)
-
-Todos:
-
-- [ ] 1 command to start a capture phase
-- [ ] 1 command to upload capture artefacts to S3
-- [ ] Verify phase gets added to rspec run
-- [ ] Verify phase can use uploaded data
+- Data should be versioned (S3 bucket is versioned)
+- Data should be protected (S3 credentials are needed)
+- Data should be retrievable (S3 credentials available on CI, read only!)

--- a/lib/data_test.rb
+++ b/lib/data_test.rb
@@ -1,0 +1,67 @@
+# frozen_string_literal: true
+
+require_relative "data_test/subject"
+require_relative "data_test/file_helpers"
+require_relative "data_test/capture"
+require_relative "data_test/verifier"
+require_relative "data_test/uploader"
+require_relative "data_test/fetcher"
+require "aws-sdk-s3"
+require "zip"
+
+module DataTest
+  # This module is to help get a test flow that uses actual production
+  # data and verifies the result of new code.
+  #
+  # The main flow is to capture data `DataTest::Capture`, upload it to
+  # S3 `DataTest::Uploader` so that test runs can access it using the
+  # `DataTest::Fetcher` and verify the results with the
+  # `DataTest::Verifier`
+  #
+  # Normally you should never interact with these classes but instead
+  # execute:
+  #
+  #      # to capture (if they need to be updated due to a format change)
+  #      DB_NAME=<production-copy> bundle exec rake data_test:capture_and_upload
+  #
+  #      # To test (also gets run by CI)
+  #      bundle exec rake spec:data_test
+  #
+  # You'll need upload permissions on S3 to run the capture phase,
+  # you'll need read-only permissions to run the fetcher. If you don't
+  # have the read-only permissions, the spec will be skipped. (CI has them)
+  S3_BUCKET = "orbf-artefacts"
+  S3_REGION = "eu-central-1" # Frankfurt
+  ARTEFACT_DIR = Rails.root.join("spec", "artefacts")
+  RESULTS_DIR = Rails.root.join("tmp", "verifier")
+
+  class NoS3Configured < StandardError; end
+
+  # I think has_artefacts is more clear than artefacts.
+  # rubocop:disable Naming/PredicateName
+  def self.has_artefacts?
+    Dir.glob(File.join(ARTEFACT_DIR, "*")).grep(/yml|json/).any?
+  end
+  # rubocop:enable Naming/PredicateName
+
+  def self.clear_artefacts!
+    artefact_directory = ARTEFACT_DIR
+    Dir.foreach(artefact_directory) do |f|
+      if f != "." && f != ".." && f != ".gitkeep"
+        path = File.join(artefact_directory, f)
+        File.unlink(path)
+      end
+    end
+  end
+
+  def self.all_cases
+    test_json  = JSON.parse(File.read(Rails.root.join("config", "data_test.json")))
+    test_cases = test_json.each_with_object({}) do |(name, cases), result|
+      cases.each do |v|
+        subject = DataTest::Subject.new(name, v)
+        result[subject.name] = subject
+      end
+    end
+    test_cases
+  end
+end

--- a/lib/data_test.rb
+++ b/lib/data_test.rb
@@ -3,6 +3,7 @@
 require_relative "data_test/subject"
 require_relative "data_test/file_helpers"
 require_relative "data_test/capture"
+require_relative "data_test/compare"
 require_relative "data_test/verifier"
 require_relative "data_test/uploader"
 require_relative "data_test/fetcher"

--- a/lib/data_test/capture.rb
+++ b/lib/data_test/capture.rb
@@ -6,8 +6,9 @@ module DataTest
 
     attr_accessor :subject
 
-    def initialize(subject)
+    def initialize(subject, output_directory = ARTEFACT_DIR)
       @subject = subject
+      @output_directory = output_directory
     end
 
     def project_anchor_id
@@ -97,7 +98,7 @@ module DataTest
       parts = []
       parts << subject.name
       parts << name
-      Pathname.new("#{ARTEFACT_DIR}/#{parts.join('-')}.#{extension}")
+      Pathname.new("#{@output_directory}/#{parts.join('-')}.#{extension}")
     end
   end
 end

--- a/lib/data_test/capture.rb
+++ b/lib/data_test/capture.rb
@@ -1,0 +1,103 @@
+# frozen_string_literal: true
+
+module DataTest
+  class Capture
+    include FileHelpers
+
+    attr_accessor :subject
+
+    def initialize(subject)
+      @subject = subject
+    end
+
+    def project_anchor_id
+      @project_anchor_id ||= Project.find(subject.project_id).project_anchor_id
+    end
+
+    def project
+      @project ||= Project.fully_loaded.find(subject.project_id)
+    end
+
+    def invoicing_period
+      "#{subject.year}Q#{subject.quarter}"
+    end
+
+    def engine_version
+      version = 3
+      version = project.engine_version if project.engine_version > 1
+      version
+    end
+
+    def call
+      invoicing_request = InvoicingRequest.new(entity:         subject.orgunit_ext_id,
+                                               year:           subject.year,
+                                               quarter:        subject.quarter,
+                                               engine_version: engine_version)
+      options = Invoicing::InvoicingOptions.new(
+        publish_to_dhis2: false,
+        force_project_id: subject.project_id
+      )
+      invoice_entity = Invoicing::InvoiceEntity.new(project.project_anchor,
+                                                    invoicing_request,
+                                                    options)
+      invoice_entity.call
+      solver = invoice_entity.fetch_and_solve.solver
+
+      password = project.password.dup
+      capture_artefacts(invoice_entity, project)
+      check_for_sensitive_data!(password)
+      capture_results(solver, invoice_entity.fetch_and_solve.exported_values)
+    end
+
+    def capture_artefacts(invoice_entity, project)
+      dump_data_compound(invoice_entity.data_compound)
+      dump_pyramid(invoice_entity.pyramid)
+      dump_input_values(invoice_entity.fetch_and_solve.dhis2_values)
+
+      dump_project(project, invoice_entity.data_compound.indicators)
+    end
+
+    def dump_data_compound(compound)
+      record_yaml(path_for_artefact("data-compound", "yml"), compound)
+    end
+
+    def dump_pyramid(pyramid)
+      record_yaml(path_for_artefact("pyramid", "yml"), pyramid)
+    end
+
+    def dump_input_values(values)
+      inputs = values.select do |value|
+        value["storedBy"]
+      end
+      record_json(path_for_artefact("input-values", "json"), inputs)
+    end
+
+    def dump_project(project, indicators)
+      project.dhis2_url = "https://redacted.example.com"
+      project.user = "redacted"
+      project.password = "redacted"
+      data = MapProjectToOrbfProject.new(project, indicators, engine_version).map
+      record_yaml(path_for_artefact("project", "yml"), data)
+    end
+
+    def check_for_sensitive_data!(password)
+      result = `grep #{Shellwords.escape(password)} #{ARTEFACT_DIR}/*`
+      abort "Passwords leaked! => \n#{result}" unless result.empty?
+      result = `grep #{CGI.escape(password)} #{ARTEFACT_DIR}/*`
+      abort "Passwords leaked! => \n#{result}" unless result.empty?
+    end
+
+    def capture_results(solver, exported_values)
+      record_json(path_for_artefact("problem", "json"), solver.build_problem)
+      record_json(path_for_artefact("solution", "json"), solver.solution)
+      record_json(path_for_artefact("exported_values", "json"), exported_values)
+    end
+
+    def path_for_artefact(name, extension)
+      parts = []
+      parts << subject.name
+      parts << name
+      Pathname.new("#{ARTEFACT_DIR}/#{parts.join('-')}.#{extension}")
+    end
+  end
+end

--- a/lib/data_test/capture.rb
+++ b/lib/data_test/capture.rb
@@ -81,9 +81,9 @@ module DataTest
     end
 
     def check_for_sensitive_data!(password)
-      result = `grep #{Shellwords.escape(password)} #{ARTEFACT_DIR}/*`
+      result = `grep -F #{Shellwords.escape(password)} #{ARTEFACT_DIR}/*`
       abort "Passwords leaked! => \n#{result}" unless result.empty?
-      result = `grep #{CGI.escape(password)} #{ARTEFACT_DIR}/*`
+      result = `grep -F #{CGI.escape(password)} #{ARTEFACT_DIR}/*`
       abort "Passwords leaked! => \n#{result}" unless result.empty?
     end
 

--- a/lib/data_test/compare.rb
+++ b/lib/data_test/compare.rb
@@ -1,0 +1,147 @@
+# frozen_string_literal: true
+
+module DataTest
+  class Compare
+    include FileHelpers
+
+    attr_accessor :subject
+
+    class Result
+      attr_accessor :short, :key_count, :full, :message
+
+      def initialize(success:, message: "", short: [], key_count: 0, full: [])
+        @success = success
+        @message = message
+        @short = short
+        @key_count = key_count
+        @full = full
+      end
+
+      def success?
+        !!@success
+      end
+
+      def ok_message
+        ["\033[1;32mok\033[0m", message].compact.join(" ")
+      end
+
+      def fail_message
+        "\033[1;31mNot OK\033[0m"
+      end
+    end
+
+    def initialize(subject, new_directory, original_directory = ARTEFACT_DIR)
+      @subject = subject
+      @new_directory = new_directory
+      @original_directory = original_directory
+    end
+
+    def filenames_for(filename)
+      file_a = File.join(@original_directory, filename)
+      file_b = File.join(@new_directory, filename)
+      [file_a, file_b]
+    end
+
+    def file_not_found_result
+      Result.new(success: true, message: "NEW FILE")
+    end
+
+    def simple_diff(filename)
+      file_a, file_b = filenames_for(filename)
+      return file_not_found_result unless File.exist?(file_a)
+      result = `diff -q #{file_a} #{file_b}`
+
+      Result.new(success: result.strip.empty?, message: result.strip)
+    end
+
+    def json_diff(filename)
+      file_a, file_b = filenames_for(filename)
+      return file_not_found_result unless File.exist?(file_a)
+      a = JSON.parse(File.open(file_a).read)
+      b = JSON.parse(File.open(file_b).read)
+      result = JsonDiff.diff(a, b, include_was: true)
+      if result.empty?
+        Result.new(success: true)
+      else
+        Result.new(success: false, key_count: [a.keys.count, b.keys.count], short: result.sample(10), full: result)
+      end
+    end
+
+    def hash_diff(filename)
+      file_a, file_b = filenames_for(filename)
+      return file_not_found_result unless File.exist?(file_a)
+      a = JSON.parse(File.open(file_a).read)
+      b = JSON.parse(File.open(file_b).read)
+      diff = HashDiff.diff(a, b, use_lcs: false)
+      if diff.empty?
+        Result.new(success: true)
+      else
+        Result.new(success: false, key_count: [a.count, b.count], short: diff.sample(10), full: diff)
+      end
+    end
+
+    def handle_simple_diff(name, result)
+      print "  \033[1m#{name}\033[0m"
+      if result.success?
+        puts "    #{result.ok_message}"
+      else
+        puts "    #{result.fail_message}"
+        puts "    File change #{result.short}"
+      end
+    end
+
+    def handle_json_diff(name, result)
+      print "  \033[1m#{name}\033[0m"
+      if result.success?
+        puts "    #{result.ok_message}"
+      else
+        puts "    #{result.fail_message}"
+        puts "    + Differences (first 10 out of #{result.full.count})"
+        result.short.each do |item|
+          puts "      [%s] Was: %s Is: %s Path: %s" % [item["op"], item["was"], item["value"], item["path"]]
+        end
+      end
+    end
+
+    def handle_hash_diff(name, result)
+      print "  \033[1m#{name}\033[0m"
+      if result.success?
+        puts "    #{result.ok_message}"
+      else
+        puts "    #{result.fail_message}"
+        puts "    + Differences (first 10 out of #{result.full.count})"
+        result.short.each do |arr|
+          puts "      [%s] Was: %s Is: %s Path: %s" % [arr[0], arr[2], arr[3], arr[1]]
+        end
+      end
+    end
+
+    def call
+      puts " [input files]"
+      filename = subject.filename("input-values", "json")
+      handle_hash_diff(filename, hash_diff(filename))
+      [
+        ["project", "yml"],
+        ["data-compound", "yml"],
+        ["pyramid", "yml"]
+      ].each do |(name, extension)|
+        filename = subject.filename(name, extension)
+        result = simple_diff(filename)
+        handle_simple_diff(filename, result)
+      end
+
+      puts " [result files]"
+      [
+        ["problem", "json"],
+        ["solution", "json"]
+      ].each do |(name, extension)|
+        filename = subject.filename(name, extension)
+        result = json_diff(filename)
+        handle_json_diff(filename, result)
+      end
+
+      filename = subject.filename("exported_values", "json")
+      handle_hash_diff(filename, hash_diff(filename))
+    end
+  end
+end

--- a/lib/data_test/fetcher.rb
+++ b/lib/data_test/fetcher.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+module DataTest
+  class Fetcher
+    attr_accessor :s3
+
+    def initialize
+      credentials = Aws::Credentials.new(access_key, secret)
+      Aws.config.update(region:      S3_REGION,
+                        credentials: credentials)
+      @s3 = Aws::S3::Resource.new(region: S3_REGION)
+    end
+
+    def access_key
+      ENV["ARCHIVAL_S3_ACCESS"] || ENV["FETCHER_S3_ACCESS"]
+    end
+
+    def secret
+      ENV["ARCHIVAL_S3_KEY"] || ENV["FETCHER_S3_KEY"]
+    end
+
+    def can_run?
+      !!access_key && !!secret
+    end
+
+    def bucket
+      s3.bucket(S3_BUCKET)
+    end
+
+    def fetch_all_artefacts
+      get_and_extract_zip(ARTEFACT_DIR)
+    end
+
+    def get(name, output_path)
+      obj = bucket.object(name)
+      obj.get(response_target: output_path)
+    rescue Aws::S3::Errors::InvalidAccessKeyId => e
+      raise NoS3Configured, e.to_s
+    end
+
+    def get_and_extract_zip(output_directory, name: "latest.zip")
+      DataTest.clear_artefacts!
+      output_file = Tempfile.new("latest.zip")
+      get(name, output_file.path)
+      Zip::File.open(output_file.path) do |zip_file|
+        zip_file.each do |entry|
+          output_path = File.join(output_directory, entry.name)
+          puts "  -> Extracting #{entry.name}"
+          entry.extract(output_path)
+        end
+      end
+      output_file.unlink
+    end
+  end
+end

--- a/lib/data_test/fetcher.rb
+++ b/lib/data_test/fetcher.rb
@@ -32,6 +32,15 @@ module DataTest
       s3.bucket(S3_BUCKET)
     end
 
+    def fetch_config_file
+      if DataTest.has_config_file?
+        puts "  -> Config file found"
+      else
+        puts "  -> Downloading config file"
+        get("data_test.json", CONFIG_PATH)
+      end
+    end
+
     def fetch_all_artefacts
       get_and_extract_zip(ARTEFACT_DIR)
     end
@@ -44,13 +53,14 @@ module DataTest
     end
 
     def get_and_extract_zip(output_directory, name: "latest.zip")
-      DataTest.clear_artefacts!
       output_file = Tempfile.new("latest.zip")
+      puts "  -> Fetching #{name}"
       get(name, output_file.path)
+      puts "  -> Extracting to #{output_directory}"
       Zip::File.open(output_file.path) do |zip_file|
         zip_file.each do |entry|
           output_path = File.join(output_directory, entry.name)
-          puts "  -> Extracting #{entry.name}"
+          File.unlink(output_path) if File.exist?(output_path)
           entry.extract(output_path)
         end
       end

--- a/lib/data_test/fetcher.rb
+++ b/lib/data_test/fetcher.rb
@@ -20,7 +20,12 @@ module DataTest
     end
 
     def can_run?
-      !!access_key && !!secret
+      !!access_key && !!secret && !!S3_REGION
+    end
+
+    def self.can_run?
+      return false unless !!S3_REGION
+      new.can_run?
     end
 
     def bucket

--- a/lib/data_test/file_helpers.rb
+++ b/lib/data_test/file_helpers.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+module DataTest
+  module FileHelpers
+    def read_yaml(file_path)
+      YAML.load_file(file_path)
+    end
+
+    def record_yaml(file_path, yamlable)
+      puts "  -> Writing #{file_path}"
+      File.open(file_path, "w") do |f|
+        f.write yamlable.to_yaml
+      end
+    end
+
+    def read_json(file_path)
+      JSON.parse(File.read(file_path))
+    rescue StandardError
+      raise "Could not read #{file_path}"
+    end
+
+    def record_json(file_path, jsonable)
+      puts "  -> Writing #{file_path}"
+      File.open(file_path, "w") do |f|
+        f.write jsonable.to_json
+      end
+    end
+  end
+end

--- a/lib/data_test/subject.rb
+++ b/lib/data_test/subject.rb
@@ -30,5 +30,9 @@ module DataTest
     def name
       "#{project_name}-#{orgunit_ext_id}"
     end
+
+    def filename(file, extension)
+      "#{[name, file].join("-")}.#{extension}"
+    end
   end
 end

--- a/lib/data_test/subject.rb
+++ b/lib/data_test/subject.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+require "uri"
+
+module DataTest
+  class Subject
+    attr_accessor :project_name, :project_id, :year, :quarter, :orgunit_ext_id
+
+    def initialize(project_name, hash)
+      if (url = hash["url"])
+        hash = Subject.url_to_hash(url)
+      end
+      @project_name = project_name
+      @project_id = hash.fetch("project_id")
+      @year = hash.fetch("year")
+      @quarter = hash.fetch("quarter")
+      @orgunit_ext_id = hash.fetch("orgunit_ext_id")
+    end
+
+    def self.url_to_hash(url)
+      uri = URI.parse(url)
+      parts = uri.query.split("&").each_with_object({}) do |s, r|
+        key, value = s.split("=")
+        key = "orgunit_ext_id" if key == "entity"
+        r[key] = value
+      end
+      parts.merge!("project_id" => uri.path.match(%r{projects/(\d+)/})[1])
+    end
+
+    def name
+      "#{project_name}-#{orgunit_ext_id}"
+    end
+  end
+end

--- a/lib/data_test/uploader.rb
+++ b/lib/data_test/uploader.rb
@@ -1,0 +1,60 @@
+# frozen_string_literal: true
+
+module DataTest
+  class Uploader
+    attr_accessor :s3
+
+    def initialize
+      credentials = Aws::Credentials.new(access_key, secret)
+      Aws.config.update(region:      S3_REGION,
+                        credentials: credentials)
+      @s3 = Aws::S3::Resource.new(region: S3_REGION)
+    end
+
+    def access_key
+      ENV["ARCHIVAL_S3_ACCESS"]
+    end
+
+    def secret
+      ENV["ARCHIVAL_S3_KEY"]
+    end
+
+    def can_run?
+      !!access_key && !!secret
+    end
+
+    def bucket
+      s3.bucket(S3_BUCKET)
+    end
+
+    def store_all_artefacts
+      all_artefacts = Pathname.new(ARTEFACT_DIR).join("*").to_s
+      all_paths = Dir.glob(all_artefacts).grep(/yml|json/)
+      store_zip(all_paths)
+    end
+
+    def store(file_path, name: nil)
+      path = Pathname.new(file_path)
+      file_name = name || path.basename.to_s
+      obj = bucket.object(file_name)
+      obj.upload_file(path.to_s)
+    rescue Aws::S3::Errors::InvalidAccessKeyId => e
+      raise NoS3Configured, e.to_s
+    end
+
+    def store_zip(array_of_paths, name: "latest.zip")
+      array_of_paths = Array.wrap(array_of_paths)
+      zip_file = Tempfile.new("latest.zip")
+      puts "  -> Zipping"
+      Zip::File.open(zip_file.path, Zip::File::CREATE) do |zipfile|
+        array_of_paths.each do |path|
+          path = Pathname.new(path)
+          zipfile.add(path.basename, path.to_s)
+        end
+      end
+      puts "  -> Uploading"
+      store(zip_file.path, name: name)
+      zip_file.unlink
+    end
+  end
+end

--- a/lib/data_test/uploader.rb
+++ b/lib/data_test/uploader.rb
@@ -23,6 +23,11 @@ module DataTest
       !!access_key && !!secret
     end
 
+    def self.can_run?
+      return false unless !!S3_REGION
+      new.can_run?
+    end
+
     def bucket
       s3.bucket(S3_BUCKET)
     end

--- a/lib/data_test/uploader.rb
+++ b/lib/data_test/uploader.rb
@@ -32,6 +32,10 @@ module DataTest
       s3.bucket(S3_BUCKET)
     end
 
+    def store_config_file
+      store(CONFIG_PATH, name: "data_test.json")
+    end
+
     def store_all_artefacts
       all_artefacts = Pathname.new(ARTEFACT_DIR).join("*").to_s
       all_paths = Dir.glob(all_artefacts).grep(/yml|json/)
@@ -57,7 +61,7 @@ module DataTest
           zipfile.add(path.basename, path.to_s)
         end
       end
-      puts "  -> Uploading"
+      puts "  -> Uploading #{name}"
       store(zip_file.path, name: name)
       zip_file.unlink
     end

--- a/lib/data_test/verifier.rb
+++ b/lib/data_test/verifier.rb
@@ -1,0 +1,67 @@
+# frozen_string_literal: true
+require "fileutils"
+
+module DataTest
+  class Verifier
+    include FileHelpers
+
+    attr_accessor :subject
+
+    def initialize(subject)
+      @subject = subject
+      ensure_directory_exists
+    end
+
+    def read_artefact(name, extension)
+      parts = []
+      parts << subject.name
+      parts << name
+      path = Pathname.new("#{ARTEFACT_DIR}/#{parts.join('-')}.#{extension}")
+      if extension == "json"
+        read_json(path)
+      else
+        read_yaml(path)
+      end
+    end
+
+    def call
+      DataCompound
+      invoicing_request = InvoicingRequest.new(
+        entity:      subject.orgunit_ext_id,
+        year:        subject.year,
+        quarter:     subject.quarter,
+        mocked_data: read_artefact("input-values", "json")
+      )
+      options = Invoicing::InvoicingOptions.new(
+        publish_to_dhis2: false,
+        force_project_id: subject.project_id
+      )
+      invoice_entity = Invoicing::InvoiceEntity.new(nil, invoicing_request, options)
+      invoice_entity.instance_variable_set(:@pyramid, read_artefact("pyramid", "yml"))
+      invoice_entity.instance_variable_set(:@datacompound, read_artefact("data-compound", "yml"))
+      invoice_entity.instance_variable_set(:@orbf_project, read_artefact("project", "yml"))
+      invoice_entity.call
+      solver = invoice_entity.fetch_and_solve.solver
+      capture_results(solver, invoice_entity.fetch_and_solve.exported_values)
+    end
+
+    def ensure_directory_exists
+      unless File.exist? RESULTS_DIR
+        FileUtils.mkdir_p RESULTS_DIR
+      end
+    end
+
+    def path_for_result(name, extension)
+      parts = []
+      parts << subject.name
+      parts << name
+      Pathname.new("#{RESULTS_DIR}/#{parts.join('-')}.#{extension}")
+    end
+
+    def capture_results(solver, exported_values)
+      record_json(path_for_result("problem", "json"), solver.build_problem)
+      record_json(path_for_result("solution", "json"), solver.solution)
+      record_json(path_for_result("exported_values", "json"), exported_values)
+    end
+  end
+end

--- a/lib/tasks/data_test.rake
+++ b/lib/tasks/data_test.rake
@@ -80,6 +80,7 @@ namespace :data_test do
     puts "=> Uploading to S3+\n"
     uploader = DataTest::Uploader.new
     begin
+      uploader.store_config_file
       uploader.store_all_artefacts
     rescue DataTest::NoS3Configured => e
       abort "S3 was not configured properly: #{e}"
@@ -91,6 +92,27 @@ namespace :data_test do
     fetcher = DataTest::Fetcher.new
     begin
       fetcher.fetch_all_artefacts
+    rescue DataTest::NoS3Configured => e
+      abort "S3 was not configured properly: #{e}"
+    end
+  end
+
+  desc "Download config file"
+  task download_config: :environment do
+    fetcher = DataTest::Fetcher.new
+    begin
+      fetcher.fetch_config_file
+    rescue DataTest::NoS3Configured => e
+      abort "S3 was not configured properly: #{e}"
+    end
+  end
+
+  desc "Upload config file"
+  task upload_config: :environment do
+    uploader = DataTest::Uploader.new
+    begin
+      puts "=> Uploading to S3"
+      uploader.store_config_file
     rescue DataTest::NoS3Configured => e
       abort "S3 was not configured properly: #{e}"
     end

--- a/lib/tasks/data_test.rake
+++ b/lib/tasks/data_test.rake
@@ -1,0 +1,78 @@
+# frozen_string_literal: true
+
+require "shellwords"
+require_relative "../data_test"
+
+namespace :data_test do
+  desc "Clear all artefacts"
+  task :clear_artefacts do
+    puts "=> Clearing existing artefacts"
+    DataTest.clear_artefacts!
+  end
+
+  desc "Run simulation and capture all artefacts"
+  task capture: :environment do
+    puts "=> Capturing\n"
+    test_cases = DataTest.all_cases
+    selected_test_case_name = ENV["test_case"] || "all"
+
+    if selected_test_case_name != "all"
+      test_cases = test_cases.select { |(_name, _cases)| k =~ /#{selected_test_case_name}/ }
+    end
+
+    failures = {}
+    test_cases.each.with_index do |(test_case_name, subject), i|
+      begin
+        puts "+ #{i + 1}/#{test_cases.keys.count} #{subject.project_name} - #{subject.orgunit_ext_id}"
+        DataTest::Capture.new(subject).call
+      rescue StandardError => error
+        puts "  -> FAILED"
+        failures[test_case_name] = error
+        raise error if ENV["FAIL_FAST"]
+      end
+    end
+    if failures.empty?
+      puts "  -> Captured them all in #{DataTest::ARTEFACT_DIR}"
+    else
+      puts failures
+      abort "Encountered failures. Stopping"
+    end
+  end
+
+  task check_upload_credentials: :environment do
+    uploader = DataTest::Uploader.new
+    unless uploader.can_run?
+      abort "You don't have S3 configured. Upload would fail so not even starting"
+    end
+  end
+
+  task capture_and_upload: %i[check_upload_credentials clear_artefacts capture upload environment] do
+    # Thanks to the magic of rake, it will now:
+    # - check if you can upload
+    # - clear any existing artefacts
+    # - generate new artefacts
+    # - zips them and uploads them to S3
+    puts "All done. `latest.zip` will now be available on S3"
+  end
+
+  desc "Upload artefacts"
+  task upload: :environment do
+    puts "=> Uploading to S3+\n"
+    uploader = DataTest::Uploader.new
+    begin
+      uploader.store_all_artefacts
+    rescue DataTest::NoS3Configured => e
+      abort "S3 was not configured properly: #{e}"
+    end
+  end
+
+  desc "Download artefacts"
+  task download: :environment do
+    fetcher = DataTest::Fetcher.new
+    begin
+      fetcher.fetch_all_artefacts
+    rescue DataTest::NoS3Configured => e
+      abort "S3 was not configured properly: #{e}"
+    end
+  end
+end

--- a/lib/tasks/data_test.rake
+++ b/lib/tasks/data_test.rake
@@ -17,7 +17,7 @@ namespace :data_test do
     selected_test_case_name = ENV["test_case"] || "all"
 
     if selected_test_case_name != "all"
-      test_cases = test_cases.select { |(_name, _cases)| k =~ /#{selected_test_case_name}/ }
+      test_cases = test_cases.select { |(name, _cases)| name =~ /#{selected_test_case_name}/ }
     end
 
     failures = {}

--- a/lib/tasks/data_test.rake
+++ b/lib/tasks/data_test.rake
@@ -61,8 +61,7 @@ namespace :data_test do
   end
 
   task check_upload_credentials: :environment do
-    uploader = DataTest::Uploader.new
-    unless uploader.can_run?
+    unless DataTest::Uploader.can_run?
       abort "You don't have S3 configured. Upload would fail so not even starting"
     end
   end

--- a/lib/tasks/data_test.rake
+++ b/lib/tasks/data_test.rake
@@ -12,7 +12,10 @@ namespace :data_test do
 
   desc "Run simulation and capture all artefacts"
   task capture: :environment do
-    puts "=> Capturing\n"
+    output_directory = Rails.root.join("tmp/new_artefacts")
+    FileUtils.mkdir(output_directory) unless File.exist? output_directory
+
+    puts "=> Capturing to #{output_directory}\n"
     test_cases = DataTest.all_cases
     selected_test_case_name = ENV["test_case"] || "all"
 
@@ -24,7 +27,7 @@ namespace :data_test do
     test_cases.each.with_index do |(test_case_name, subject), i|
       begin
         puts "+ #{i + 1}/#{test_cases.keys.count} #{subject.project_name} - #{subject.orgunit_ext_id}"
-        DataTest::Capture.new(subject).call
+        DataTest::Capture.new(subject, output_directory).call
       rescue StandardError => error
         puts "  -> FAILED"
         failures[test_case_name] = error
@@ -32,7 +35,7 @@ namespace :data_test do
       end
     end
     if failures.empty?
-      puts "  -> Captured them all in #{DataTest::ARTEFACT_DIR}"
+      puts "  -> Captured them all in #{output_directory}"
     else
       puts failures
       abort "Encountered failures. Stopping"

--- a/lib/tasks/spec.rake
+++ b/lib/tasks/spec.rake
@@ -23,12 +23,20 @@ namespace :spec do
     ]
     run_commands(cmds)
   end
+
+  desc "Run full data test"
+  task :data_test do
+    cmds = [
+      %w[rspec spec --tag @data_test]
+    ]
+    run_commands(cmds)
+  end
 end
 
 desc "Run specs (without system)"
 task :spec do
   cmds = [
-    %w[rspec spec --color --tag ~@type:system]
+    %w[rspec spec --color --tag ~@type:system --tag ~@data_test]
   ]
   run_commands(cmds)
 end

--- a/script/bootstrap
+++ b/script/bootstrap
@@ -56,7 +56,7 @@ if [ -f "Gemfile" ]; then
     }
 fi
 
-bundle exec ruby -e 'require "hesabu"; File.file?(Hesabu::HESABUCLI + "k") ? exit(0) : exit(1)' >/dev/null 2>&1  || {
+bundle exec ruby -e 'require "hesabu"; File.file?(Hesabu::HESABUCLI) ? exit(0) : exit(1)' >/dev/null 2>&1  || {
     cat <<HESABU
 You don't seem to have a binary for the hesabu gem.
 

--- a/script/cibuild
+++ b/script/cibuild
@@ -24,3 +24,7 @@ script/test
 echo "[cibuild] Running system tests ..."
 date "+%H:%M:%S"
 SKIP_SIMPLECOV=1 bundle exec rails spec:system
+
+echo "[cibuild] Running data tests ..."
+date "+%H:%M:%S"
+SKIP_SIMPLECOV=1 bundle exec rails spec:data_test

--- a/script/setup
+++ b/script/setup
@@ -16,6 +16,13 @@ else
     cp config/database-template.yml.example config/database.yml
 fi
 
+if [ -f "config/application.yml" ] ; then
+    true
+else
+    echo "==> Generating config/application.yml"
+    cp config/application.template.yml config/application.yml
+fi
+
 echo "==> Setting up DB…"
 # reset database to a fresh state.
 bin/rake db:reset db:create

--- a/spec/lib/data_test_spec.rb
+++ b/spec/lib/data_test_spec.rb
@@ -41,7 +41,7 @@ if DataTest::Fetcher.new.can_run?
           result = JsonDiff.diff(original, new, include_was: true)
           unless result.empty?
             puts "  + original: #{original.keys.count} vs new: #{new.keys.count}"
-            puts "  + diff (first 10): #{result.first(10)}"
+            puts "  + diff (first 10): #{result.sample(10)}"
           end
           expect(result).to be_empty
         end
@@ -52,7 +52,7 @@ if DataTest::Fetcher.new.can_run?
           result = JsonDiff.diff(original, new, include_was: true)
           unless result.empty?
             puts "  + original: #{original.keys.count} vs new: #{new.keys.count}"
-            puts "  + diff (first 10): #{result.first(10)}"
+            puts "  + diff (first 10): #{result.sample(10)}"
           end
           expect(result).to be_empty
         end
@@ -63,7 +63,7 @@ if DataTest::Fetcher.new.can_run?
           diff = HashDiff.diff(original, new, use_lcs: false)
           unless diff.empty?
             puts "  + original: #{original.count} vs new: #{new.count}"
-            puts "  + diff (first 10): #{diff.first(10)}"
+            puts "  + diff (first 10): #{diff.sample(10)}"
           end
           expect(diff).to be_empty
         end

--- a/spec/lib/data_test_spec.rb
+++ b/spec/lib/data_test_spec.rb
@@ -71,10 +71,17 @@ if DataTest::Fetcher.can_run?
     end
   end
 else
-  puts <<DESC
+  message = <<DESC
 No FETCHER_S3_ACCESS and FETCHER_S3_KEY found in ENV-variables.
 
 These are needed to download the artefacts to verify the results with,
 so now skipping.
 DESC
+  if ENV["CI"]
+    it 'has S3 configured' do
+      fail message
+    end
+  else
+    puts message
+  end
 end

--- a/spec/lib/data_test_spec.rb
+++ b/spec/lib/data_test_spec.rb
@@ -1,0 +1,80 @@
+require "rails_helper"
+require "data_test"
+
+def artefact(name)
+  JSON.parse(File.open(File.join(DataTest::ARTEFACT_DIR, name)).read)
+end
+
+def result(name)
+  JSON.parse(File.open(File.join(DataTest::RESULTS_DIR,name)).read)
+end
+
+if DataTest::Fetcher.new.can_run?
+  RSpec.describe "Data Test", data_test: true do
+    before(:all) do
+      if DataTest.has_artefacts?
+        puts "Artefacts found (no new download)"
+      else
+        puts "Downloading artefacts"
+        WebMock.allow_net_connect!
+        fetcher = DataTest::Fetcher.new
+        fetcher.fetch_all_artefacts
+        WebMock.disable_net_connect!
+      end
+    end
+
+    after(:all) do
+      puts "Clearing artefacts"
+      DataTest.clear_artefacts!
+    end
+
+    DataTest.all_cases.each do |name, subject|
+      describe "#{name}" do
+        before(:all) do
+          puts "  -> Running simulation and saving data"
+          DataTest::Verifier.new(subject).call
+        end
+
+        it "problem" do
+          original = artefact("#{name}-problem.json")
+          new = result("#{name}-problem.json")
+          result = JsonDiff.diff(original, new, include_was: true)
+          unless result.empty?
+            puts "  + original: #{original.keys.count} vs new: #{new.keys.count}"
+            puts "  + diff (first 10): #{result.first(10)}"
+          end
+          expect(result).to be_empty
+        end
+
+        it "solution" do
+          original = artefact("#{name}-solution.json")
+          new = result("#{name}-solution.json")
+          result = JsonDiff.diff(original, new, include_was: true)
+          unless result.empty?
+            puts "  + original: #{original.keys.count} vs new: #{new.keys.count}"
+            puts "  + diff (first 10): #{result.first(10)}"
+          end
+          expect(result).to be_empty
+        end
+
+        it "exported_values" do
+          original = artefact("#{name}-exported_values.json")
+          new = result("#{name}-exported_values.json")
+          diff = HashDiff.diff(original, new, use_lcs: false)
+          unless diff.empty?
+            puts "  + original: #{original.count} vs new: #{new.count}"
+            puts "  + diff (first 10): #{diff.first(10)}"
+          end
+          expect(diff).to be_empty
+        end
+      end
+    end
+  end
+else
+  puts <<DESC
+No FETCHER_S3_ACCESS and FETCHER_S3_KEY found in ENV-variables.
+
+These are needed to download the artefacts to verify the results with,
+so now skipping.
+DESC
+end

--- a/spec/lib/data_test_spec.rb
+++ b/spec/lib/data_test_spec.rb
@@ -9,8 +9,8 @@ def result(name)
   JSON.parse(File.open(File.join(DataTest::RESULTS_DIR,name)).read)
 end
 
-if DataTest::Fetcher.can_run?
-  RSpec.describe "Data Test", data_test: true do
+RSpec.describe "Data Test", data_test: true do
+  if DataTest::Fetcher.can_run?
     before(:all) do
       if DataTest.has_artefacts?
         puts "Artefacts found (no new download)"
@@ -69,19 +69,19 @@ if DataTest::Fetcher.can_run?
         end
       end
     end
-  end
-else
-  message = <<DESC
+  else
+    message = <<DESC
 No FETCHER_S3_ACCESS and FETCHER_S3_KEY found in ENV-variables.
 
 These are needed to download the artefacts to verify the results with,
 so now skipping.
 DESC
-  if ENV["CI"]
-    it 'has S3 configured' do
-      fail message
+    if ENV["CI"]
+      it 'has S3 configured' do
+        fail message
+      end
+    else
+      puts message
     end
-  else
-    puts message
   end
 end

--- a/spec/lib/data_test_spec.rb
+++ b/spec/lib/data_test_spec.rb
@@ -9,7 +9,7 @@ def result(name)
   JSON.parse(File.open(File.join(DataTest::RESULTS_DIR,name)).read)
 end
 
-if DataTest::Fetcher.new.can_run?
+if DataTest::Fetcher.can_run?
   RSpec.describe "Data Test", data_test: true do
     before(:all) do
       if DataTest.has_artefacts?

--- a/spec/lib/data_test_spec.rb
+++ b/spec/lib/data_test_spec.rb
@@ -25,7 +25,7 @@ if DataTest::Fetcher.can_run?
 
     after(:all) do
       puts "Clearing artefacts"
-      DataTest.clear_artefacts!
+      DataTest.clear_artefacts! unless DataTest.keep_artefacts?
     end
 
     DataTest.all_cases.each do |name, subject|

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -23,6 +23,7 @@ unless ENV['SKIP_SIMPLECOV']
     coverage_dir  "./coverage"
     add_filter    "/spec/"
     add_filter    "/vendor/ruby"
+    add_filter    "lib/datatest"
 
     add_group "Libraries", "lib/tasks/"
   end


### PR DESCRIPTION
## Objective

We want an automated, reliable check to see if adjustments made to:

- hesabu
- hesabu-go
- orbf-rules_engine
- orbf2

Have an impact on previously made calculations.

In order to do this we've identified several projects and org units that we want to check by using production data and comparing the results to a newer version.

## How is it solved?

See `lib/data_test.rb`, it's a module which has helpers for the various parts:

- `lib/data_test/capture.rb` -> Capturing the artefacts
- `lib/data_test/verifier.rb` -> Verifying the results
- `lib/data_test/uploader.rb` -> Upload to S3
- `lib/data_test/fetcher.rb` -> Fetchhing from S3

Normally we don't interact with those classes, since the verifier gets run by the spec suite (`rake spec:data_test`) and the capture and upload is also available as a single rake task (`rake data_test:capture_and_upload`)

I've now captured artefacts on the current master branch and stored them on S3, so CI will now always compare against that dataset.

## High level overview

- Capture phase
- Verify phase

### Capture Phase

Take a snapshot of current production data, load it locally and execute a command to capture all the data needed to generate an invoice. The end goal is to have a set of data that:

- Works independently of DHIS2 availability
- Works without access to production database

This will run with the code as it was last deployed in production, these results should be captured but should never be committed to the repository (since they might contain sensitive production data).

### Verify Phase

With new code, like in a feature-branch, load a simulation with the data of the capture phase and compare the results against the results of the capture phase. This should work without access to DHIS2 or access to the production database.

## How to store capture phase data?

Since capture phase data should be treated as sensitive data, it should never be committed to the repo. Instead the results of the capure phase should be uploaded to a protected S3 bucket. The verify phase could use env variables to be able to download the results and then run against those files.

Currently these artefacts are generated:

Data to inflate to a known situation:

- `<name>-<orgunit>-data-compound.yml` (a YAML serialization of `DataCompound`)
- `<name>-<orgunit>-project.yml` (a YAML serialization of a `Project`)
- `<name>-<orgunit>-pyramid.yml` (a YAML serialization of the complete pyramid)
- `<name>-<orgunit>-input-values.json` (a JSON containing all DHIS2-input values)

Results:

- `<name>-<orgunit>-problem.json` (a JSON containing the problem that will be sent to hesabu)
- `<name>-<orgunit>-solution.json` (a JSON containing the solution coming out of hesabu)
- `<name>-<orgunit>-exported_values.json` (a JSON containing all values that would be exported)

Things we are looking for:

- Data should be versioned
- Data should be protected
- Data should be retrievable

What I'd propose is to have the capture phase (on a successfull run):

- upload the individual files to S3
- Have the S3 bucket be setup to be versioned
- Zip all the files and upload to S3 (for easier access)

On a verify phase the ENV will be checked for the URL of the zip:

- Zip would be downloaded and extracted
- Verify phase would run against those files
- Verify phase gets run on CI and results are displayed there (careful about leaking data in a public CI)

Todos:

- [x] 1 command to start a capture phase
- [x] 1 command to upload capture artefacts to S3
- [x] Verify phase gets added to rspec run
- [x] Verify phase can use uploaded data
