### PR TITLE
Avoid double construction of pyramid

### DIFF
--- a/app/models/project_anchor.rb
+++ b/app/models/project_anchor.rb
@@ -37,7 +37,7 @@ class ProjectAnchor < ApplicationRecord
     projects.where(status: "draft").fully_loaded.last
   end
 
-  def nearest_pyramid_for(date)
+  def nearest_pyramid_snapshot_for(date)
     kinds = %i[organisation_units organisation_unit_groups organisation_unit_group_sets]
     pyramid_snapshots = dhis2_snapshots.select("id, year, month, kind").where(kind: kinds)
 
@@ -51,6 +51,13 @@ class ProjectAnchor < ApplicationRecord
     final_snapshots = final_candidates.map { |kind, candidate| [kind, candidate ? dhis2_snapshots.find(candidate.id) : nil] }
                                       .to_h
     return nil if final_snapshots.values.compact.size != kinds.size
+    final_snapshots
+  end
+
+  def nearest_pyramid_for(date)
+    final_snapshots = nearest_pyramid_snapshot_for(date)
+    return nil unless final_snapshots
+
     new_pyramid(final_snapshots)
   end
 


### PR DESCRIPTION
The pyramid is now only constructed once (in the orbf rules engine
gem), instead of doint it twice.

~This change needs the pj/performance-tweaks branch of orb rules engine to be merged first.~
Changed was merged, and this PR updates orbf-rules_engine

## Self proof reading checklist

- [x] Did I run Pronto and fixed all warnings (pronto run -c origin/dev)
- [x] Make sure all naming and code will remain understandable in 6 month by someone new to the project or by you.
- [x] Did I test the right thing?
- [x] Did I test corner cases, non happy path (defensive testing)?
- [x] Check that I used the ad-hoc patterns and created files accordingly (Presenters, Services, Search object, Form object,...)
- [x] Check code efficiency with record intensive project
- [x] Update documentation,readme accordingly

Thanks!
