### PR TITLE
Parallel http requests

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -48,3 +48,5 @@ Naming/VariableNumber:
 # this one triggers a lot of false positive as orbf rules are "%{}"-based
 Style/FormatStringToken:
   EnforcedStyle: template
+Rails/Delegate:
+  Enabled: false

--- a/Gemfile
+++ b/Gemfile
@@ -75,7 +75,9 @@ else
   gem "hesabu", github: "BLSQ/hesabu"
   gem "orbf-rules_engine", github: "BLSQ/orbf-rules_engine"
 end
-
+# Like a modern code version of the mythical beast with 100 serpent hea...
+# [typhoeus](https://github.com/typhoeus/typhoeus)
+gem "typhoeus", "~> 1.3.1"
 group :development, :test do
   gem "byebug", platform: :mri
   gem "database_cleaner"

--- a/Gemfile
+++ b/Gemfile
@@ -29,6 +29,12 @@ gem "figaro"
 gem "lograge", "~> 0.10.0"
 gem "sentry-raven", "~> 2.7.4"
 
+# Feature flipper is the act of enabling/disabling features in your app...
+# [flipper](https://github.com/jnunemaker/flipper)
+gem "flipper", "~> 0.16.1"
+gem "flipper-active_record", "~> 0.16.1"
+gem "flipper-ui", "~> 0.16.1"
+
 ## Frontend and asset related
 
 gem "bootstrap-datepicker-rails"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -14,7 +14,7 @@ GIT
 
 GIT
   remote: https://github.com/BLSQ/orbf-rules_engine.git
-  revision: c6be7e240ccf42eee017611f570342b5309e6a29
+  revision: a0642a6a43efcbd1198767ee976e51eabc9313e1
   specs:
     orbf-rules_engine (0.1.0)
       activesupport
@@ -151,6 +151,8 @@ GEM
       unf (>= 0.0.5, < 1.0.0)
     erubi (1.7.1)
     erubis (2.7.0)
+    ethon (0.12.0)
+      ffi (>= 1.3.0)
     execjs (2.7.0)
     factory_bot (4.11.1)
       activesupport (>= 3.0.0)
@@ -465,6 +467,8 @@ GEM
     turbolinks (5.2.0)
       turbolinks-source (~> 5.2)
     turbolinks-source (5.2.0)
+    typhoeus (1.3.1)
+      ethon (>= 0.9.0)
     tzinfo (1.2.5)
       thread_safe (~> 0.1)
     uglifier (4.1.20)
@@ -564,6 +568,7 @@ DEPENDENCIES
   sprockets (~> 3.7.2)
   stackprof
   turbolinks (~> 5)
+  typhoeus (~> 1.3.1)
   tzinfo-data
   uglifier (>= 1.3.0)
   web-console

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -174,6 +174,15 @@ GEM
       path_expander (~> 1.0)
       ruby_parser (~> 3.0)
       sexp_processor (~> 4.0)
+    flipper (0.16.1)
+    flipper-active_record (0.16.1)
+      activerecord (>= 3.2, < 6)
+      flipper (~> 0.16.1)
+    flipper-ui (0.16.1)
+      erubis (~> 2.7.0)
+      flipper (~> 0.16.1)
+      rack (>= 1.4, < 3)
+      rack-protection (>= 1.5.3, < 2.1.0)
     font-awesome-rails (4.7.0.4)
       railties (>= 3.2, < 6.0)
     font-awesome-sass (4.7.0)
@@ -518,6 +527,9 @@ DEPENDENCIES
   fast_jsonapi
   figaro
   flamegraph
+  flipper (~> 0.16.1)
+  flipper-active_record (~> 0.16.1)
+  flipper-ui (~> 0.16.1)
   font-awesome-sass (~> 4.7.0)
   hashdiff
   heroku-deflater

--- a/app/models/project_anchor.rb
+++ b/app/models/project_anchor.rb
@@ -139,4 +139,8 @@ class ProjectAnchor < ApplicationRecord
     indicators = snapshots.find(&:kind_indicators?)
     new_data_compound(data_elements, data_element_groups, indicators)
   end
+
+  def flipper_id
+    "ProjectAnchor:#{id}"
+  end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -48,4 +48,8 @@ class User < ApplicationRecord
   def label
     "User##{id} - #{email}"
   end
+
+  def flipper_id
+    "User:#{id}"
+  end
 end

--- a/config/application.rb
+++ b/config/application.rb
@@ -41,5 +41,6 @@ module Scorpio
 
     # These are defined in `/lib/*.rb
     require "scorpio"
+    require "parallel_dhis2"
   end
 end

--- a/config/initializers/feature_flipper.rb
+++ b/config/initializers/feature_flipper.rb
@@ -1,0 +1,11 @@
+require 'flipper/adapters/active_record'
+
+Flipper.configure do |config|
+  config.default do
+    # pick an adapter, this uses memory, any will do
+    adapter = Flipper::Adapters::ActiveRecord.new
+
+    # pass adapter to handy DSL instance
+    Flipper.new(adapter)
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -10,6 +10,16 @@ Rails.application.routes.draw do
   Sidekiq::Throttled::Web.enhance_queues_tab!
   mount Sidekiq::Web => "/sidekiq"
 
+  if ENV["ADMIN_PASSWORD"]
+    flipper_app = Flipper::UI.app(Flipper) do |builder|
+      builder.use Rack::Auth::Basic do |username, password|
+        username == "admin" && password == ENV["ADMIN_PASSWORD"]
+      end
+    end
+  else
+    flipper_app = Flipper::UI.app(Flipper)
+  end
+  mount flipper_app => '/flipper'
   mount RailsAdmin::Engine => "/admin", as: "rails_admin"
 
   devise_for :users

--- a/db/migrate/20190214095526_create_flipper_tables.rb
+++ b/db/migrate/20190214095526_create_flipper_tables.rb
@@ -1,0 +1,22 @@
+class CreateFlipperTables < ActiveRecord::Migration[5.2]
+  def self.up
+    create_table :flipper_features do |t|
+      t.string :key, null: false
+      t.timestamps null: false
+    end
+    add_index :flipper_features, :key, unique: true
+
+    create_table :flipper_gates do |t|
+      t.string :feature_key, null: false
+      t.string :key, null: false
+      t.string :value
+      t.timestamps null: false
+    end
+    add_index :flipper_gates, [:feature_key, :key, :value], unique: true
+  end
+
+  def self.down
+    drop_table :flipper_gates
+    drop_table :flipper_features
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,309 +10,325 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20181204093346) do
+ActiveRecord::Schema.define(version: 2019_02_14_095526) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
   enable_extension "uuid-ossp"
 
-  create_table "activities", force: :cascade do |t|
-    t.string   "name",                                             null: false
-    t.integer  "project_id",                                       null: false
-    t.uuid     "stable_id",  default: -> { "uuid_generate_v4()" }, null: false
-    t.datetime "created_at",                                       null: false
-    t.datetime "updated_at",                                       null: false
-    t.string   "code"
-    t.string   "short_name"
-    t.index ["name", "project_id"], name: "index_activities_on_name_and_project_id", unique: true, using: :btree
-    t.index ["project_id", "code"], name: "index_activities_on_project_id_and_code", unique: true, using: :btree
-    t.index ["project_id"], name: "index_activities_on_project_id", using: :btree
+  create_table "activities", id: :serial, force: :cascade do |t|
+    t.string "name", null: false
+    t.integer "project_id", null: false
+    t.uuid "stable_id", default: -> { "uuid_generate_v4()" }, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.string "code"
+    t.string "short_name"
+    t.index ["name", "project_id"], name: "index_activities_on_name_and_project_id", unique: true
+    t.index ["project_id", "code"], name: "index_activities_on_project_id_and_code", unique: true
+    t.index ["project_id"], name: "index_activities_on_project_id"
   end
 
-  create_table "activity_packages", force: :cascade do |t|
-    t.integer  "activity_id",                                       null: false
-    t.integer  "package_id",                                        null: false
-    t.uuid     "stable_id",   default: -> { "uuid_generate_v4()" }, null: false
-    t.datetime "created_at",                                        null: false
-    t.datetime "updated_at",                                        null: false
-    t.index ["activity_id"], name: "index_activity_packages_on_activity_id", using: :btree
-    t.index ["package_id", "activity_id"], name: "index_activity_packages_on_package_id_and_activity_id", unique: true, using: :btree
-    t.index ["package_id"], name: "index_activity_packages_on_package_id", using: :btree
+  create_table "activity_packages", id: :serial, force: :cascade do |t|
+    t.integer "activity_id", null: false
+    t.integer "package_id", null: false
+    t.uuid "stable_id", default: -> { "uuid_generate_v4()" }, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["activity_id"], name: "index_activity_packages_on_activity_id"
+    t.index ["package_id", "activity_id"], name: "index_activity_packages_on_package_id_and_activity_id", unique: true
+    t.index ["package_id"], name: "index_activity_packages_on_package_id"
   end
 
-  create_table "activity_states", force: :cascade do |t|
-    t.string   "external_reference"
-    t.string   "name",                                                     null: false
-    t.integer  "state_id",                                                 null: false
-    t.integer  "activity_id",                                              null: false
-    t.uuid     "stable_id",          default: -> { "uuid_generate_v4()" }, null: false
-    t.datetime "created_at",                                               null: false
-    t.datetime "updated_at",                                               null: false
-    t.string   "kind",               default: "data_element",              null: false
-    t.string   "formula"
-    t.index ["activity_id"], name: "index_activity_states_on_activity_id", using: :btree
-    t.index ["external_reference", "activity_id"], name: "index_activity_states_on_external_reference_and_activity_id", unique: true, using: :btree
-    t.index ["state_id"], name: "index_activity_states_on_state_id", using: :btree
+  create_table "activity_states", id: :serial, force: :cascade do |t|
+    t.string "external_reference"
+    t.string "name", null: false
+    t.integer "state_id", null: false
+    t.integer "activity_id", null: false
+    t.uuid "stable_id", default: -> { "uuid_generate_v4()" }, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.string "kind", default: "data_element", null: false
+    t.string "formula"
+    t.index ["activity_id"], name: "index_activity_states_on_activity_id"
+    t.index ["external_reference", "activity_id"], name: "index_activity_states_on_external_reference_and_activity_id", unique: true
+    t.index ["state_id"], name: "index_activity_states_on_state_id"
   end
 
-  create_table "decision_tables", force: :cascade do |t|
+  create_table "decision_tables", id: :serial, force: :cascade do |t|
     t.integer "rule_id"
-    t.text    "content"
-    t.index ["rule_id"], name: "index_decision_tables_on_rule_id", using: :btree
+    t.text "content"
+    t.index ["rule_id"], name: "index_decision_tables_on_rule_id"
   end
 
-  create_table "dhis2_logs", force: :cascade do |t|
-    t.jsonb    "sent"
-    t.jsonb    "status"
-    t.integer  "project_anchor_id"
-    t.datetime "created_at",        null: false
-    t.datetime "updated_at",        null: false
-    t.index ["project_anchor_id"], name: "index_dhis2_logs_on_project_anchor_id", using: :btree
+  create_table "dhis2_logs", id: :serial, force: :cascade do |t|
+    t.jsonb "sent"
+    t.jsonb "status"
+    t.integer "project_anchor_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["project_anchor_id"], name: "index_dhis2_logs_on_project_anchor_id"
   end
 
-  create_table "dhis2_snapshot_changes", force: :cascade do |t|
-    t.string   "dhis2_id",          null: false
-    t.integer  "dhis2_snapshot_id"
-    t.jsonb    "values_before"
-    t.jsonb    "values_after"
-    t.string   "whodunnit"
-    t.datetime "created_at",        null: false
-    t.datetime "updated_at",        null: false
-    t.index ["dhis2_snapshot_id"], name: "index_dhis2_snapshot_changes_on_dhis2_snapshot_id", using: :btree
+  create_table "dhis2_snapshot_changes", id: :serial, force: :cascade do |t|
+    t.string "dhis2_id", null: false
+    t.integer "dhis2_snapshot_id"
+    t.jsonb "values_before"
+    t.jsonb "values_after"
+    t.string "whodunnit"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["dhis2_snapshot_id"], name: "index_dhis2_snapshot_changes_on_dhis2_snapshot_id"
   end
 
-  create_table "dhis2_snapshots", force: :cascade do |t|
-    t.string   "kind",              null: false
-    t.jsonb    "content",           null: false
-    t.integer  "project_anchor_id"
-    t.string   "dhis2_version",     null: false
-    t.integer  "year",              null: false
-    t.integer  "month",             null: false
-    t.string   "job_id",            null: false
-    t.datetime "created_at",        null: false
-    t.datetime "updated_at",        null: false
-    t.index ["project_anchor_id"], name: "index_dhis2_snapshots_on_project_anchor_id", using: :btree
+  create_table "dhis2_snapshots", id: :serial, force: :cascade do |t|
+    t.string "kind", null: false
+    t.jsonb "content", null: false
+    t.integer "project_anchor_id"
+    t.string "dhis2_version", null: false
+    t.integer "year", null: false
+    t.integer "month", null: false
+    t.string "job_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["project_anchor_id"], name: "index_dhis2_snapshots_on_project_anchor_id"
   end
 
-  create_table "entity_groups", force: :cascade do |t|
-    t.string   "name"
-    t.string   "external_reference"
-    t.integer  "project_id"
-    t.datetime "created_at",                                      null: false
-    t.datetime "updated_at",                                      null: false
-    t.boolean  "limit_snaphot_to_active_regions", default: false, null: false
-    t.index ["project_id"], name: "index_entity_groups_on_project_id", using: :btree
+  create_table "entity_groups", id: :serial, force: :cascade do |t|
+    t.string "name"
+    t.string "external_reference"
+    t.integer "project_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.boolean "limit_snaphot_to_active_regions", default: false, null: false
+    t.index ["project_id"], name: "index_entity_groups_on_project_id"
   end
 
-  create_table "formula_mappings", force: :cascade do |t|
-    t.integer "formula_id",         null: false
+  create_table "flipper_features", force: :cascade do |t|
+    t.string "key", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["key"], name: "index_flipper_features_on_key", unique: true
+  end
+
+  create_table "flipper_gates", force: :cascade do |t|
+    t.string "feature_key", null: false
+    t.string "key", null: false
+    t.string "value"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["feature_key", "key", "value"], name: "index_flipper_gates_on_feature_key_and_key_and_value", unique: true
+  end
+
+  create_table "formula_mappings", id: :serial, force: :cascade do |t|
+    t.integer "formula_id", null: false
     t.integer "activity_id"
-    t.string  "external_reference", null: false
-    t.string  "kind",               null: false
-    t.index ["activity_id"], name: "index_formula_mappings_on_activity_id", using: :btree
-    t.index ["formula_id"], name: "index_formula_mappings_on_formula_id", using: :btree
+    t.string "external_reference", null: false
+    t.string "kind", null: false
+    t.index ["activity_id"], name: "index_formula_mappings_on_activity_id"
+    t.index ["formula_id"], name: "index_formula_mappings_on_formula_id"
   end
 
-  create_table "formulas", force: :cascade do |t|
-    t.string   "code",                    null: false
-    t.string   "description",             null: false
-    t.text     "expression",              null: false
-    t.integer  "rule_id"
-    t.datetime "created_at",              null: false
-    t.datetime "updated_at",              null: false
-    t.string   "frequency"
-    t.string   "short_name"
-    t.string   "exportable_formula_code"
-    t.index ["rule_id"], name: "index_formulas_on_rule_id", using: :btree
+  create_table "formulas", id: :serial, force: :cascade do |t|
+    t.string "code", null: false
+    t.string "description", null: false
+    t.text "expression", null: false
+    t.integer "rule_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.string "frequency"
+    t.string "short_name"
+    t.string "exportable_formula_code"
+    t.index ["rule_id"], name: "index_formulas_on_rule_id"
   end
 
-  create_table "invoicing_jobs", force: :cascade do |t|
-    t.integer  "project_anchor_id", null: false
-    t.string   "orgunit_ref",       null: false
-    t.string   "dhis2_period",      null: false
-    t.string   "user_ref"
+  create_table "invoicing_jobs", id: :serial, force: :cascade do |t|
+    t.integer "project_anchor_id", null: false
+    t.string "orgunit_ref", null: false
+    t.string "dhis2_period", null: false
+    t.string "user_ref"
     t.datetime "processed_at"
     t.datetime "errored_at"
-    t.string   "last_error"
-    t.integer  "duration_ms"
-    t.string   "status"
-    t.string   "sidekiq_job_ref"
-    t.datetime "created_at",        null: false
-    t.datetime "updated_at",        null: false
-    t.index ["project_anchor_id", "orgunit_ref", "dhis2_period"], name: "index_invoicing_jobs_on_anchor_ou_period", unique: true, using: :btree
-    t.index ["project_anchor_id"], name: "index_invoicing_jobs_on_project_anchor_id", using: :btree
+    t.string "last_error"
+    t.integer "duration_ms"
+    t.string "status"
+    t.string "sidekiq_job_ref"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["project_anchor_id", "orgunit_ref", "dhis2_period"], name: "index_invoicing_jobs_on_anchor_ou_period", unique: true
+    t.index ["project_anchor_id"], name: "index_invoicing_jobs_on_project_anchor_id"
   end
 
-  create_table "package_entity_groups", force: :cascade do |t|
-    t.string   "name"
-    t.integer  "package_id"
-    t.string   "organisation_unit_group_ext_ref"
-    t.datetime "created_at",                                       null: false
-    t.datetime "updated_at",                                       null: false
-    t.string   "kind",                            default: "main", null: false
-    t.index ["package_id"], name: "index_package_entity_groups_on_package_id", using: :btree
+  create_table "package_entity_groups", id: :serial, force: :cascade do |t|
+    t.string "name"
+    t.integer "package_id"
+    t.string "organisation_unit_group_ext_ref"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.string "kind", default: "main", null: false
+    t.index ["package_id"], name: "index_package_entity_groups_on_package_id"
   end
 
-  create_table "package_payment_rules", force: :cascade do |t|
-    t.integer  "package_id",      null: false
-    t.integer  "payment_rule_id", null: false
-    t.datetime "created_at",      null: false
-    t.datetime "updated_at",      null: false
-    t.index ["package_id"], name: "index_package_payment_rules_on_package_id", using: :btree
-    t.index ["payment_rule_id"], name: "index_package_payment_rules_on_payment_rule_id", using: :btree
+  create_table "package_payment_rules", id: :serial, force: :cascade do |t|
+    t.integer "package_id", null: false
+    t.integer "payment_rule_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["package_id"], name: "index_package_payment_rules_on_package_id"
+    t.index ["payment_rule_id"], name: "index_package_payment_rules_on_payment_rule_id"
   end
 
-  create_table "package_states", force: :cascade do |t|
-    t.integer  "package_id"
-    t.integer  "state_id"
-    t.datetime "created_at",             null: false
-    t.datetime "updated_at",             null: false
-    t.string   "ds_external_reference"
-    t.string   "deg_external_reference"
-    t.string   "de_external_reference"
-    t.index ["package_id", "state_id"], name: "index_package_states_on_package_id_and_state_id", unique: true, using: :btree
-    t.index ["package_id"], name: "index_package_states_on_package_id", using: :btree
-    t.index ["state_id", "package_id"], name: "index_package_states_on_state_id_and_package_id", unique: true, using: :btree
-    t.index ["state_id"], name: "index_package_states_on_state_id", using: :btree
+  create_table "package_states", id: :serial, force: :cascade do |t|
+    t.integer "package_id"
+    t.integer "state_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.string "ds_external_reference"
+    t.string "deg_external_reference"
+    t.string "de_external_reference"
+    t.index ["package_id", "state_id"], name: "index_package_states_on_package_id_and_state_id", unique: true
+    t.index ["package_id"], name: "index_package_states_on_package_id"
+    t.index ["state_id", "package_id"], name: "index_package_states_on_state_id_and_package_id", unique: true
+    t.index ["state_id"], name: "index_package_states_on_state_id"
   end
 
-  create_table "packages", force: :cascade do |t|
-    t.string   "name",                                                             null: false
-    t.string   "data_element_group_ext_ref",                                       null: false
-    t.string   "frequency",                                                        null: false
-    t.integer  "project_id"
-    t.datetime "created_at",                                                       null: false
-    t.datetime "updated_at",                                                       null: false
-    t.uuid     "stable_id",                  default: -> { "uuid_generate_v4()" }, null: false
-    t.string   "kind",                       default: "single"
-    t.string   "ogs_reference"
-    t.string   "groupsets_ext_refs",         default: [],                                       array: true
-    t.index ["project_id"], name: "index_packages_on_project_id", using: :btree
+  create_table "packages", id: :serial, force: :cascade do |t|
+    t.string "name", null: false
+    t.string "data_element_group_ext_ref", null: false
+    t.string "frequency", null: false
+    t.integer "project_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.uuid "stable_id", default: -> { "uuid_generate_v4()" }, null: false
+    t.string "kind", default: "single"
+    t.string "ogs_reference"
+    t.string "groupsets_ext_refs", default: [], array: true
+    t.index ["project_id"], name: "index_packages_on_project_id"
   end
 
-  create_table "payment_rule_datasets", force: :cascade do |t|
-    t.integer  "payment_rule_id"
-    t.string   "frequency"
-    t.string   "external_reference"
+  create_table "payment_rule_datasets", id: :serial, force: :cascade do |t|
+    t.integer "payment_rule_id"
+    t.string "frequency"
+    t.string "external_reference"
     t.datetime "last_synched_at"
-    t.string   "last_error"
-    t.boolean  "desynchronized"
-    t.datetime "created_at",         null: false
-    t.datetime "updated_at",         null: false
-    t.index ["payment_rule_id", "frequency"], name: "index_payment_rule_datasets_on_payment_rule_id_and_frequency", unique: true, using: :btree
-    t.index ["payment_rule_id"], name: "index_payment_rule_datasets_on_payment_rule_id", using: :btree
-  end
-
-  create_table "payment_rules", force: :cascade do |t|
-    t.integer  "project_id",                       null: false
-    t.datetime "created_at",                       null: false
-    t.datetime "updated_at",                       null: false
-    t.string   "frequency",  default: "quarterly", null: false
-    t.index ["project_id"], name: "index_payment_rules_on_project_id", using: :btree
-  end
-
-  create_table "programs", force: :cascade do |t|
-    t.string   "code",       null: false
+    t.string "last_error"
+    t.boolean "desynchronized"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.index ["code"], name: "index_programs_on_code", unique: true, using: :btree
+    t.index ["payment_rule_id", "frequency"], name: "index_payment_rule_datasets_on_payment_rule_id_and_frequency", unique: true
+    t.index ["payment_rule_id"], name: "index_payment_rule_datasets_on_payment_rule_id"
   end
 
-  create_table "project_anchors", force: :cascade do |t|
-    t.integer  "program_id", null: false
+  create_table "payment_rules", id: :serial, force: :cascade do |t|
+    t.integer "project_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.string   "token"
-    t.index ["program_id"], name: "index_project_anchors_on_program_id", using: :btree
+    t.string "frequency", default: "quarterly", null: false
+    t.index ["project_id"], name: "index_payment_rules_on_project_id"
   end
 
-  create_table "projects", force: :cascade do |t|
-    t.string   "name",                                        null: false
-    t.string   "dhis2_url",                                   null: false
-    t.string   "user"
-    t.string   "password"
-    t.boolean  "bypass_ssl",            default: false
-    t.boolean  "boolean",               default: false
-    t.datetime "created_at",                                  null: false
-    t.datetime "updated_at",                                  null: false
-    t.string   "status",                default: "draft",     null: false
+  create_table "programs", id: :serial, force: :cascade do |t|
+    t.string "code", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["code"], name: "index_programs_on_code", unique: true
+  end
+
+  create_table "project_anchors", id: :serial, force: :cascade do |t|
+    t.integer "program_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.string "token"
+    t.index ["program_id"], name: "index_project_anchors_on_program_id"
+  end
+
+  create_table "projects", id: :serial, force: :cascade do |t|
+    t.string "name", null: false
+    t.string "dhis2_url", null: false
+    t.string "user"
+    t.string "password"
+    t.boolean "bypass_ssl", default: false
+    t.boolean "boolean", default: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.string "status", default: "draft", null: false
     t.datetime "publish_date"
-    t.integer  "project_anchor_id"
-    t.integer  "original_id"
-    t.string   "cycle",                 default: "quarterly", null: false
-    t.integer  "engine_version",        default: 1,           null: false
-    t.string   "qualifier"
-    t.string   "default_coc_reference"
-    t.string   "default_aoc_reference"
-    t.index ["project_anchor_id"], name: "index_projects_on_project_anchor_id", using: :btree
+    t.integer "project_anchor_id"
+    t.integer "original_id"
+    t.string "cycle", default: "quarterly", null: false
+    t.integer "engine_version", default: 1, null: false
+    t.string "qualifier"
+    t.string "default_coc_reference"
+    t.string "default_aoc_reference"
+    t.index ["project_anchor_id"], name: "index_projects_on_project_anchor_id"
   end
 
-  create_table "rules", force: :cascade do |t|
-    t.string   "name",                                                  null: false
-    t.string   "kind",                                                  null: false
-    t.integer  "package_id"
-    t.datetime "created_at",                                            null: false
-    t.datetime "updated_at",                                            null: false
-    t.integer  "payment_rule_id"
-    t.uuid     "stable_id",       default: -> { "uuid_generate_v4()" }, null: false
-    t.index ["package_id"], name: "index_rules_on_package_id", using: :btree
-    t.index ["payment_rule_id"], name: "index_rules_on_payment_rule_id", using: :btree
+  create_table "rules", id: :serial, force: :cascade do |t|
+    t.string "name", null: false
+    t.string "kind", null: false
+    t.integer "package_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.integer "payment_rule_id"
+    t.uuid "stable_id", default: -> { "uuid_generate_v4()" }, null: false
+    t.index ["package_id"], name: "index_rules_on_package_id"
+    t.index ["payment_rule_id"], name: "index_rules_on_payment_rule_id"
   end
 
-  create_table "states", force: :cascade do |t|
-    t.string   "name",                            null: false
-    t.datetime "created_at",                      null: false
-    t.datetime "updated_at",                      null: false
-    t.string   "level",      default: "activity", null: false
-    t.integer  "project_id",                      null: false
-    t.string   "short_name"
-    t.index ["project_id", "name"], name: "index_states_on_project_id_and_name", unique: true, using: :btree
-    t.index ["project_id"], name: "index_states_on_project_id", using: :btree
+  create_table "states", id: :serial, force: :cascade do |t|
+    t.string "name", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.string "level", default: "activity", null: false
+    t.integer "project_id", null: false
+    t.string "short_name"
+    t.index ["project_id", "name"], name: "index_states_on_project_id_and_name", unique: true
+    t.index ["project_id"], name: "index_states_on_project_id"
   end
 
-  create_table "users", force: :cascade do |t|
-    t.string   "email",                  default: "", null: false
-    t.string   "encrypted_password",     default: "", null: false
-    t.string   "reset_password_token"
+  create_table "users", id: :serial, force: :cascade do |t|
+    t.string "email", default: "", null: false
+    t.string "encrypted_password", default: "", null: false
+    t.string "reset_password_token"
     t.datetime "reset_password_sent_at"
     t.datetime "remember_created_at"
-    t.integer  "sign_in_count",          default: 0,  null: false
+    t.integer "sign_in_count", default: 0, null: false
     t.datetime "current_sign_in_at"
     t.datetime "last_sign_in_at"
-    t.inet     "current_sign_in_ip"
-    t.inet     "last_sign_in_ip"
-    t.datetime "created_at",                          null: false
-    t.datetime "updated_at",                          null: false
-    t.integer  "program_id"
-    t.index ["email"], name: "index_users_on_email", unique: true, using: :btree
-    t.index ["program_id"], name: "index_users_on_program_id", using: :btree
-    t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true, using: :btree
+    t.inet "current_sign_in_ip"
+    t.inet "last_sign_in_ip"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.integer "program_id"
+    t.index ["email"], name: "index_users_on_email", unique: true
+    t.index ["program_id"], name: "index_users_on_program_id"
+    t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end
 
-  create_table "version_associations", force: :cascade do |t|
+  create_table "version_associations", id: :serial, force: :cascade do |t|
     t.integer "version_id"
-    t.string  "foreign_key_name", null: false
+    t.string "foreign_key_name", null: false
     t.integer "foreign_key_id"
-    t.index ["foreign_key_name", "foreign_key_id"], name: "index_version_associations_on_foreign_key", using: :btree
-    t.index ["version_id"], name: "index_version_associations_on_version_id", using: :btree
+    t.index ["foreign_key_name", "foreign_key_id"], name: "index_version_associations_on_foreign_key"
+    t.index ["version_id"], name: "index_version_associations_on_version_id"
   end
 
-  create_table "versions", force: :cascade do |t|
-    t.string   "item_type",      null: false
-    t.integer  "item_id",        null: false
-    t.string   "event",          null: false
-    t.string   "whodunnit"
-    t.text     "old_object"
+  create_table "versions", id: :serial, force: :cascade do |t|
+    t.string "item_type", null: false
+    t.integer "item_id", null: false
+    t.string "event", null: false
+    t.string "whodunnit"
+    t.text "old_object"
     t.datetime "created_at"
-    t.integer  "transaction_id"
-    t.jsonb    "object"
-    t.integer  "program_id"
-    t.integer  "project_id"
-    t.jsonb    "object_changes"
-    t.index ["item_type", "item_id"], name: "index_versions_on_item_type_and_item_id", using: :btree
-    t.index ["program_id"], name: "index_versions_on_program_id", using: :btree
-    t.index ["project_id"], name: "index_versions_on_project_id", using: :btree
-    t.index ["transaction_id"], name: "index_versions_on_transaction_id", using: :btree
+    t.integer "transaction_id"
+    t.jsonb "object"
+    t.integer "program_id"
+    t.integer "project_id"
+    t.jsonb "object_changes"
+    t.index ["item_type", "item_id"], name: "index_versions_on_item_type_and_item_id"
+    t.index ["program_id"], name: "index_versions_on_program_id"
+    t.index ["project_id"], name: "index_versions_on_project_id"
+    t.index ["transaction_id"], name: "index_versions_on_transaction_id"
   end
 
   add_foreign_key "activities", "projects"

--- a/lib/data_test.rb
+++ b/lib/data_test.rb
@@ -62,6 +62,11 @@ module DataTest
   end
   # rubocop:enable Naming/PredicateName
 
+  def self.clear_config_file!
+    return unless has_config_file?
+    File.unlink(CONFIG_PATH)
+  end
+
   def self.clear_artefacts!
     artefact_directory = ARTEFACT_DIR
     Dir.foreach(artefact_directory) do |f|
@@ -73,6 +78,7 @@ module DataTest
   end
 
   def self.all_cases
+    return {} unless has_config_file?
     test_json  = JSON.parse(File.read(CONFIG_PATH))
     test_cases = test_json.each_with_object({}) do |(name, cases), result|
       cases.each do |v|

--- a/lib/parallel_dhis2.rb
+++ b/lib/parallel_dhis2.rb
@@ -1,0 +1,258 @@
+# frozen_string_literal: true
+
+class ParallelDhis2
+  # A class that takes a regular `Dhis2::Client` and allows us to use
+  # parallel requests to send data values. It does this by using the
+  # `typhoeus` gem, which handles all the parallelization without us
+  # having to worry about it.
+  #
+  #      client = Dhis2::Client.new(dhis_configuration)
+  #      parallel_dhis2 = ParallelDhis2.new(client)
+  #      parallel_dhis2.post_data_value_sets(array_of_data_values)
+  #
+  # This class tries to borrow as much configuration from the regular
+  # DHIS2 client as possible, it also tries to mimick the behavior of
+  # the regular client.
+  #
+  # This means that the response gotten from `post_data_value_sets`
+  # will be a `Dhis2::Status` as well, the only difference will be
+  # that the `Dhis2::Status#raw_status` will contain a rolled up
+  # version of the parallel requests being made.
+  #
+  # If HTTP errors are encountered, similar to the normal client,
+  # exceptions will be raised, these are not the same ones that the
+  # `Dhis2::Client` is raising (they would raise `RestClient`
+  # exceptions, while here we're using our own namespace).
+  class HttpError < StandardError; end
+  class TimedOut < HttpError; end
+  class HttpException < HttpError; end
+
+  # Amount of items to include in a single request
+  SEND_VALUES_PER = 1000
+  # Max amount of concurrent request, others will be queued until
+  # queue has room again
+  MAX_CONCURRENT_REQUESTS = 20
+
+  class RollUpResponses
+    ERROR = "ERROR"
+    WARNING = "WARNING"
+    SUCCESS = "SUCCESS"
+
+    # Takes an array of Dhis2-responses and rolls them up into one
+    # Dhis2-response which has the same layout as each of the
+    # individual ones. It will have the status of the worst one. So
+    # Error > Warning > Success.
+    def initialize(responses)
+      @responses = responses
+    end
+
+    def call
+      return {} if @responses.empty?
+
+      {
+        "status"            => status,
+        "conflicts"         => conflicts,
+        "description"       => description,
+        "import_count"      => import_count,
+        "response_type"     => response_type,
+        "import_options"    => import_options,
+        "data_set_complete" => data_set_complete
+      }
+    end
+
+    def rolled_up
+      @rolled_up ||= @responses.each_with_object({}) do |response, result|
+        response.each do |key, value|
+          result[key] ||= []
+          result[key] << value
+        end
+      end
+    end
+
+    def status
+      return ERROR if rolled_up["status"].include? ERROR
+      return WARNING if rolled_up["status"].include? WARNING
+      return SUCCESS if rolled_up["status"].include? SUCCESS
+
+      ERROR
+    end
+
+    def conflicts
+      (rolled_up["conflicts"] || []).flatten
+    end
+
+    def description
+      rolled_up["description"].uniq.join(" && ") + " [parallel]"
+    end
+
+    def import_count
+      # "{\"deleted\": 0, \"ignored\": 3, \"updated\": 411, \"imported\": 0}"
+      rolled_up["import_count"].each_with_object({}) do |hash, result|
+        hash.each do |key, value|
+          result[key] ||= 0
+          result[key] += value
+        end
+      end
+    end
+
+    def response_type
+      # Always ImportSummary
+      rolled_up["response_type"].uniq.first
+    end
+
+    def import_options
+      rolled_up["import_options"].flatten
+    end
+
+    def data_set_complete
+      # Practically always false
+      rolled_up["data_set_complete"].compact.uniq.first
+    end
+  end
+
+  class ClientWrapper
+    # Wraps a regular Dhis2::Client in a loving embrace so we can get
+    # access to `base_url`, `verify_ssl` and others.
+    #
+    # The tests are setup to break if a nicer interface than directly
+    # getting the instance variables is set up.
+    def initialize(dhis2_client)
+      @client = dhis2_client
+    end
+
+    # rubocop:disable Rails/Delegate
+    def user
+      base_uri.user
+    end
+
+    def password
+      base_uri.password
+    end
+    # rubocop:enable Rails/Delegate
+
+    def url
+      uri = base_uri.dup
+      uri.user = nil
+      uri.password = nil
+      uri.to_s
+    end
+
+    def base_uri
+      @base_uri ||= URI.parse(base_url)
+    end
+
+    # Returns a fully authenticated url to the DHIS2-instance
+    def base_url
+      @client.instance_variable_get(:@base_url)
+    end
+
+    def debug?
+      @client.instance_variable_get(:@debug)
+    end
+
+    # Returns one of these:
+    #  OpenSSL::SSL::VERIFY_NONE
+    #  OpenSSL::SSL::VERIFY_PEER
+    def verify_ssl_settings
+      @client.instance_variable_get(:@verify_ssl)
+    end
+
+    def ssl_verify_peer?
+      verify_ssl_settings == OpenSSL::SSL::VERIFY_PEER
+    end
+
+    def time_out_settings
+      @client.instance_variable_get(:@timeout)
+    end
+
+    # Most likely it will return:
+    #       {Accept: "json", Content-Type: "application/json"}
+    def post_headers
+      headers = @client.send(:headers, "post", {})
+      headers.delete(:params)
+      headers["Accept"] = headers.delete(:accept).to_s
+      headers["Content-Type"] = "application/#{headers.delete(:content_type)}"
+      headers
+    end
+  end
+
+  # dhis2_client - An instance of `Dhis2::Client`
+  def initialize(dhis2_client)
+    @client = ClientWrapper.new(dhis2_client)
+  end
+
+  def prepare_payload(payload)
+    Dhis2::Case.deep_change(payload, :camelize).to_json
+  end
+
+  def build_post_request(url, payload)
+    body = prepare_payload(payload)
+    Typhoeus::Request.new(url,
+                          method:         :post,
+                          headers:        @client.post_headers,
+                          body:           body,
+                          timeout:        @client.time_out_settings,
+                          ssl_verifypeer: @client.ssl_verify_peer?,
+                          userpwd:        [@client.user, @client.password].join(":"))
+  end
+
+  def post_data_value_sets(all_values)
+    hydra = Typhoeus::Hydra.new(max_concurrency: MAX_CONCURRENT_REQUESTS)
+    requests = []
+    url = File.join(@client.url, "api", "dataValueSets")
+    all_values.each_slice(SEND_VALUES_PER).with_index do |values, i|
+      request = build_post_request(url, dataValues: values)
+      if @client.debug?
+        request.on_complete do |response|
+          # rubocop:disable Style/FormatStringToken
+          #
+          # I like that I can use the %02d part, right in the
+          # formatting string, that's why I've disabled rubocop here.
+          message = format("[parallel_dhis2] %s [%02d] completed. (%s took %s)",
+                           url,
+                           i + 1,
+                           response.code,
+                           response.total_time)
+          # rubocop:enable Style/FormatStringToken
+          puts message
+        end
+      end
+
+      hydra.queue(request)
+      requests << request
+    end
+    # This blocks until all requests are done.
+    hydra.run
+
+    responses = requests.map(&:response)
+    parsed_responses = parse_responses(responses)
+    raw_status = RollUpResponses.new(parsed_responses).call
+    Dhis2::Status.new(raw_status)
+  end
+
+  def parse_responses(responses)
+    check_for_errors!(responses)
+
+    parsed = responses.map do |response|
+      next if [nil, ""].include?(response.body)
+
+      parsed_response = JSON.parse(response.body)
+      Dhis2::Case.deep_change(parsed_response, :underscore)
+    end
+    parsed.compact
+  end
+
+  def check_for_errors!(responses)
+    responses.each do |response|
+      next if response.success?
+
+      if response.timed_out?
+        message = "#{response.effective_url} timed out"
+        raise TimedOut, message
+      else
+        message = "#{response.effective_url} returned #{response.code}: #{response.return_message}"
+        raise HttpException, message
+      end
+    end
+  end
+end

--- a/lib/parallel_dhis2.rb
+++ b/lib/parallel_dhis2.rb
@@ -49,15 +49,16 @@ class ParallelDhis2
     def call
       return {} if @responses.empty?
 
-      {
+      response = {
         "status"            => status,
-        "conflicts"         => conflicts,
         "description"       => description,
         "import_count"      => import_count,
         "response_type"     => response_type,
         "import_options"    => import_options,
         "data_set_complete" => data_set_complete
       }
+      response.merge!("conflicts" => conflicts) if conflicts.any?
+      response
     end
 
     def rolled_up

--- a/lib/parallel_dhis2.rb
+++ b/lib/parallel_dhis2.rb
@@ -120,7 +120,6 @@ class ParallelDhis2
       @client = dhis2_client
     end
 
-    # rubocop:disable Rails/Delegate
     def user
       base_uri.user
     end
@@ -128,7 +127,6 @@ class ParallelDhis2
     def password
       base_uri.password
     end
-    # rubocop:enable Rails/Delegate
 
     def url
       uri = base_uri.dup

--- a/spec/lib/data_test_spec.rb
+++ b/spec/lib/data_test_spec.rb
@@ -18,14 +18,19 @@ RSpec.describe "Data Test", data_test: true do
         puts "Downloading artefacts"
         WebMock.allow_net_connect!
         fetcher = DataTest::Fetcher.new
+        fetcher.fetch_config_file
         fetcher.fetch_all_artefacts
         WebMock.disable_net_connect!
       end
     end
 
     after(:all) do
-      puts "Clearing artefacts"
-      DataTest.clear_artefacts! unless DataTest.keep_artefacts?
+      unless DataTest.keep_artefacts?
+        puts "Removing config file"
+        DataTest.clear_config_file!
+        puts "Clearing artefacts"
+        DataTest.clear_artefacts!
+      end
     end
 
     DataTest.all_cases.each do |name, subject|

--- a/spec/lib/parallel_dhis2_spec.rb
+++ b/spec/lib/parallel_dhis2_spec.rb
@@ -1,0 +1,269 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+def dhis2_client(options = {})
+  default_options = {
+    url:      "https://play.dhis2.org/demo",
+    user:     "admin",
+    password: "district",
+    debug:    true
+  }
+  options = default_options.merge(options)
+  Dhis2::Client.new(options)
+end
+
+def fake_response(status:, conflicts: [], description: "", import_count: {})
+  {
+    "status"            => status,
+    "conflicts"         => conflicts,
+    "description"       => description,
+    "import_count"      => import_count,
+    "response_type"     => "ImportSummary",
+    "import_options"    => { some: "data", with: "keys", more: "data" },
+    "data_set_complete" => false
+  }
+end
+
+RSpec.describe ParallelDhis2 do
+  it "#prepare_payload" do
+    parallel_dhis2 = described_class.new(dhis2_client)
+    prepared_payload = parallel_dhis2.prepare_payload(
+      [{ "my_key": 1 }, { "my_other_key": 15 }]
+    )
+    expect(prepared_payload).to eq("[{\"myKey\":1},{\"myOtherKey\":15}]")
+  end
+
+  describe "build_post_request" do
+    let(:payload) {
+      [{ "my_key": 1 }, { "my_other_key": 15 }]
+    }
+    let(:client) {
+      described_class.new(dhis2_client(timeout: 1234))
+    }
+    let(:request) {
+      client.build_post_request("http://something.example", payload)
+    }
+    it "sets headers" do
+      expect(request.options[:headers]).to include("Accept" => "json", "Content-Type" => "application/json")
+    end
+
+    it "sets ssl" do
+      expect(request.options[:ssl_verifypeer]).to eq(true)
+    end
+
+    it "sets timeout" do
+      expect(request.options[:timeout]).to eq(1234)
+    end
+
+    it "transforms body" do
+      expect(request.encoded_body).to eq(client.prepare_payload(payload))
+    end
+  end
+
+  describe "post_data_value_sets" do
+    let(:expected_url) { "https://play.dhis2.org/demo/api/dataValueSets" }
+    let(:client) {
+      described_class.new(dhis2_client(debug: false))
+    }
+
+    it "parallelizes on SEND_VALUES_PER" do
+      payload = fake_response(
+        status:       "SUCCESS",
+        description:  "Import process completed successfully",
+        import_count: { "deleted": 10, "ignored": 20, "updated": 30, "imported": 40 }
+      )
+      faked_response = Dhis2::Case.deep_change(payload, :camelize)
+      stub_request(:any, expected_url).to_return(body: faked_response.to_json)
+      number_of_times = 3
+      all_values = [{ value: 1234 }] * ParallelDhis2::SEND_VALUES_PER * number_of_times
+      client.post_data_value_sets(all_values)
+      expect(a_request(:post, expected_url)).to have_been_made.times(number_of_times)
+    end
+
+    it "raises on time out" do
+      stub_request(:any, expected_url).to_timeout
+      all_values = [{ value: 1234 }]
+      expect {
+        client.post_data_value_sets(all_values)
+      }.to raise_error ParallelDhis2::TimedOut
+    end
+
+    it "raises on 500" do
+      stub_request(:any, expected_url).to_return(status: [500, "Internal Server Error"])
+      all_values = [{ value: 1234 }]
+      expect {
+        client.post_data_value_sets(all_values)
+      }.to raise_error ParallelDhis2::HttpException
+    end
+
+    it "returns a Dhis2::Status" do
+      payload = fake_response(
+        status:       "SUCCESS",
+        description:  "Import process completed successfully",
+        import_count: { "deleted": 10, "ignored": 20, "updated": 30, "imported": 40 }
+      )
+      faked_response = Dhis2::Case.deep_change(payload, :camelize)
+      stub_request(:any, expected_url).to_return(body: faked_response.to_json)
+      all_values = [{ value: 1234 }]
+      status = client.post_data_value_sets(all_values)
+      expect(status).to be_kind_of(Dhis2::Status)
+      expect(status.success?).to eq(true)
+    end
+  end
+
+  describe ParallelDhis2::RollUpResponses do
+    describe "#call" do
+      let(:failed_response) {
+        fake_response(status:       "ERROR",
+                      conflicts:    [
+                        { value: "This", object: "123" },
+                        { value: "Other", object: "254" }
+                      ],
+                      description:  "The import process failed: Failed to update object",
+                      import_count: { "deleted": 0, "ignored": 0, "updated": 0, "imported": 0 })
+      }
+      let(:warning_response) {
+        fake_response(status:       "WARNING",
+                      conflicts:    [
+                        { value: "This", object: "123" },
+                        { value: "Other", object: "254" }
+                      ],
+                      description:  "Import process completed successfully",
+                      import_count: { "deleted": 1, "ignored": 2, "updated": 3, "imported": 4 })
+      }
+      let(:weird_response) {
+        fake_response(status: "WEIRD")
+      }
+      let(:success_response) {
+        fake_response(status:       "SUCCESS",
+                      conflicts:    [],
+                      description:  "Import process completed successfully",
+                      import_count: { "deleted": 10, "ignored": 20, "updated": 30, "imported": 40 })
+      }
+
+      describe "rolled up response" do
+        subject(:rolled_up) { described_class.new([failed_response, warning_response, success_response]).call }
+
+        it(:status) { expect(rolled_up["status"]).to eq("ERROR") }
+        it(:conflicts) { expect(rolled_up["conflicts"].count).to eq(2 + 2) }
+        it(:description) { expect(rolled_up["description"]).to eq("The import process failed: Failed to update object && Import process completed successfully [parallel]") }
+        it(:import_count) { expect(rolled_up["import_count"]).to eq(deleted: 11, ignored: 22, updated: 33, imported: 44) }
+        it(:import_options) { expect(rolled_up["import_options"].count).to eq(3) }
+        it(:data_set_complete) { expect(rolled_up["data_set_complete"]).to eq(false) }
+      end
+
+      describe "#status" do
+        it "is error if any is error" do
+          roller = described_class.new([failed_response, warning_response, success_response])
+          expect(roller.status).to eq(described_class::ERROR)
+        end
+
+        it "is warning if no errors and any is warning" do
+          roller = described_class.new([warning_response, success_response])
+          expect(roller.status).to eq(described_class::WARNING)
+        end
+
+        it "is success if no errors and no warnings" do
+          roller = described_class.new([success_response, success_response])
+          expect(roller.status).to eq(described_class::SUCCESS)
+        end
+
+        it "defaults to ERROR when unknown status" do
+          roller = described_class.new([fake_response(status: "WEIRD")])
+          expect(roller.status).to eq(described_class::ERROR)
+        end
+      end
+
+      describe "#import_count" do
+        it "sums everything" do
+          roller = described_class.new([failed_response,
+                                        weird_response,
+                                        warning_response,
+                                        success_response])
+          expect(roller.import_count[:deleted]).to eq(0 + 1 + 10)
+          expect(roller.import_count[:ignored]).to eq(0 + 2 + 20)
+          expect(roller.import_count[:updated]).to eq(0 + 3 + 30)
+          expect(roller.import_count[:imported]).to eq(0 + 4 + 40)
+        end
+      end
+    end
+  end
+
+  describe ParallelDhis2::ClientWrapper do
+    describe "#base_url" do
+      it "returns authenticated URL" do
+        client = described_class.new(dhis2_client)
+        expect(client.base_url).to eq("https://admin:district@play.dhis2.org/demo")
+      end
+
+      it "breaks if accessor is available" do
+        raise "Use accessor instead of instance variable" if dhis2_client.respond_to?(:base_url)
+      end
+    end
+
+    describe "#verify_ssl_settings" do
+      it "verify_none when SSL disabled" do
+        client_without_ssl = described_class.new(dhis2_client(no_ssl_verification: true))
+        expect(client_without_ssl.verify_ssl_settings).to eq(OpenSSL::SSL::VERIFY_NONE)
+      end
+
+      it "verify_peer when SSL disabled" do
+        client_with_ssl = described_class.new(dhis2_client)
+        expect(client_with_ssl.verify_ssl_settings).to eq(OpenSSL::SSL::VERIFY_PEER)
+      end
+
+      it "breaks if accessor is available" do
+        raise "Use accessor instead of instance variable" if dhis2_client.respond_to?(:verify_ssl)
+      end
+    end
+
+    describe "#time_out_settings" do
+      it "returns timeout when set" do
+        client = described_class.new(dhis2_client(timeout: 1234))
+        expect(client.time_out_settings).to eq(1234)
+      end
+
+      it "returns default timeout" do
+        client = described_class.new(dhis2_client)
+        expect(client.time_out_settings).to eq(120)
+      end
+
+      it "breaks if accessor is available" do
+        raise "Use accessor instead of instance variable" if dhis2_client.respond_to?(:timeout)
+      end
+    end
+
+    it "#post_headers" do
+      client = described_class.new(dhis2_client)
+      expect(client.post_headers).to eq("Accept" => "json", "Content-Type" => "application/json")
+    end
+
+    it "#user" do
+      client = described_class.new(dhis2_client)
+      expect(client.user).to eq("admin")
+    end
+
+    it "#password" do
+      client = described_class.new(dhis2_client)
+      expect(client.password).to eq("district")
+    end
+
+    describe "#url" do
+      let(:client) { described_class.new(dhis2_client) }
+
+      it { expect(client.url).to eq("https://play.dhis2.org/demo") }
+      it { expect(client.url).to_not include("admin") }
+      it { expect(client.url).to_not include("district") }
+    end
+
+    describe "#debug?" do
+      it do
+        expect(described_class.new(dhis2_client(debug: true)).debug?).to eq(true)
+      end
+      it do
+        expect(described_class.new(dhis2_client(debug: false)).debug?).to eq(false)
+      end
+    end
+  end
+end

--- a/spec/lib/parallel_dhis2_spec.rb
+++ b/spec/lib/parallel_dhis2_spec.rb
@@ -116,10 +116,6 @@ RSpec.describe ParallelDhis2 do
   describe ParallelDhis2::RollUpResponses do
     let(:failed_response) {
       fake_response(status:       "ERROR",
-                    conflicts:    [
-                      { value: "This", object: "123" },
-                      { value: "Other", object: "254" }
-                    ],
                     description:  "The import process failed: Failed to update object",
                     import_count: { "deleted": 0, "ignored": 0, "updated": 0, "imported": 0 })
     }
@@ -146,7 +142,7 @@ RSpec.describe ParallelDhis2 do
         subject(:rolled_up) { described_class.new([failed_response, warning_response, success_response]).call }
 
         it(:status) { expect(rolled_up["status"]).to eq("ERROR") }
-        it(:conflicts) { expect(rolled_up["conflicts"].count).to eq(2 + 2 + 0) }
+        it(:conflicts) { expect(rolled_up["conflicts"].count).to eq(0 + 2 + 0) }
         it(:description) { expect(rolled_up["description"]).to eq("The import process failed: Failed to update object && Import process completed successfully [parallel]") }
         it(:import_count) { expect(rolled_up["import_count"]).to eq(deleted: 11, ignored: 22, updated: 33, imported: 44) }
         it(:import_options) { expect(rolled_up["import_options"].count).to eq(3) }

--- a/spec/models/concerns/paper_trailed_spec.rb
+++ b/spec/models/concerns/paper_trailed_spec.rb
@@ -22,7 +22,9 @@ RSpec.describe PaperTrailed do
     Dhis2Snapshot,
     Dhis2SnapshotChange,
     ProjectAnchor,
-    InvoicingJob
+    InvoicingJob,
+    Flipper::Adapters::ActiveRecord::Feature,
+    Flipper::Adapters::ActiveRecord::Gate,
   ].freeze
 
   ActiveRecord::Base.descendants

--- a/spec/services/invoice_entity_spec.rb
+++ b/spec/services/invoice_entity_spec.rb
@@ -1,0 +1,41 @@
+require "rails_helper"
+
+describe Invoicing::InvoiceEntity do
+  include_context "basic_context"
+
+  describe "use_parallel_publishing" do
+    let(:project) { full_project }
+    let(:expected_url) { "http://play.dhis2.org/demo/api/dataValueSets" }
+    let(:entity) {
+      entity = Invoicing::InvoiceEntity.new(project.project_anchor, nil, nil)
+    }
+
+    let(:success_response) {
+      {
+        "status"            => "SUCCESS",
+        "description"       => "My own special description",
+        "import_count"      => { "deleted": 0, "ignored": 0, "updated": 0, "imported": 1 },
+        "response_type"     => "ImportSummary",
+        "import_options"    => { some: "data", with: "keys", more: "data" },
+        "data_set_complete" => false
+      }
+    }
+
+    it 'sends values without feature enabled' do
+      entity.instance_variable_set(:@dhis2_export_values, [{ value: 1234 }]*1001)
+      stub_request(:any, expected_url).to_return(body: success_response.to_json)
+
+      expect{ entity.publish_to_dhis2 }.to change{Dhis2Log.count}.by(1)
+      expect(a_request(:post, expected_url)).to have_been_made.times(1)
+    end
+
+    it 'sends values with feature enabled' do
+      Flipper[:use_parallel_publishing].enable(project.project_anchor)
+      entity.instance_variable_set(:@dhis2_export_values, [{ value: 1234 }]*1001)
+      stub_request(:any, expected_url).to_return(body: success_response.to_json)
+
+      expect{ entity.publish_to_dhis2 }.to change{Dhis2Log.count}.by(1)
+      expect(a_request(:post, expected_url)).to have_been_made.times(2)
+    end
+  end
+end

--- a/spec/services/project_factory_spec.rb
+++ b/spec/services/project_factory_spec.rb
@@ -28,7 +28,9 @@ describe ProjectFactory do
       InvoicingJob,
       Version,
       PaperTrail::Version,
-      PaperTrail::VersionAssociation
+      PaperTrail::VersionAssociation,
+      Flipper::Adapters::ActiveRecord::Feature,
+      Flipper::Adapters::ActiveRecord::Gate,
     ].map(&:name).map(&:to_sym)
     project.payment_rules.first.datasets.create!(frequency: "quarterly", external_reference: "fakedsid")
     count_before = count_all_models


### PR DESCRIPTION
## Why?

While publishing a rather large invoice, I found out that most of the time was spent in publishing to DHIS2.

When sending 11040 values to dhis2:

- Single request:    43 seconds (43093.83299993351)
- Parallel requests:  8 seconds (8223.681999836117)

Sending 3046 values had these results:

- Single request:  12 seconds
- Parallel rquests: 6 seconds

So big wins all around. I've also checked this on the DHIS2 side to confirm that the data is arriving.

``` sql      
select datavalue.lastupdated from datavalue 
  join organisationunit ON organisationunit.organisationunitid = datavalue.sourceid 
  join dataelement ON dataelement.dataelementid = datavalue.dataelementid 
where 
  dataelement.uid = 'WQbeZuIvhzS' and organisationunit.uid = 'XJkQtdGRO5Q';
```

And it was updating the lastupdated, it was also growing the audit table by the expected amounts.

## How?

`ParallelDhis2` uses the `typhoeus` gem to be able to make multiple concurrent requests to DHIS2, which is faster than the one huge request. ParallelDhis2 tries to mimick as much of its behavior from the normal `Dhis2::Client`, so that changes to that client or configuration are automatically taken over by ParallelDhis2.

### What's with the one huge file?

1. It's basically one class with two helper classes
2. It has a potential to be reused in other projects, so one file is
quicker to test out than a couple of files
3. I thought it was going to be smaller

## Production?

At the moment this feature is behind a feature flag (feature flags, are handled by `flipper` another gem I pulled in, to help with feature flags). The idea is to enable it for one specific `ProjectAnchor` so we can monitor the performance and results before enabling it by default.

### How to enable?

Either a console: `Flipper[:use_parallel_publishing].enable?(ProjectAnchor.find(<your-id_here>)`

Or visit `/flipper` in production and enable it using the UI (it's password protected).

## Aftermath

I've made a small adjustment to the output of the Dhis2Log that gets written by `ParallelDhis` runs, in the description will be `[parallel]` at the end. This is a small way to visually check who did the publishing.

The following snippet should paint a picture on whether it's working or not.

``` ruby
table = InvoicingJob.arel_table
anchor_id = <your_id_here>
before = InvoicingJob.where(project_anchor_id: anchor_id).where(table[:created_at].lt("20190214")).where.not(table[:duration_ms].eq(nil)).average(:duration_ms).to_f
after = InvoicingJob.where(project_anchor_id: anchor_id).where(table[:created_at].gt("20190214")).where.not(table[:duration_ms].eq(nil)).average(:duration_ms).to_f
puts "Before #{before} and After #{after}"
```

## Self proof reading checklist

- [x] Did I run Pronto and fixed all warnings (pronto run -c origin/dev)
- [x] Make sure all naming and code will remain understandable in 6 month by someone new to the project or by you.
- [x] Did I test the right thing?
- [x] Did I test corner cases, non happy path (defensive testing)?
- [x] Check that I used the ad-hoc patterns and created files accordingly (Presenters, Services, Search object, Form object,...)
- [x] Check code efficiency with record intensive project
- [x] Update documentation,readme accordingly

Thanks!
