### PR TITLE
DataTest should be loadable in production

### DIFF
--- a/lib/data_test.rb
+++ b/lib/data_test.rb
@@ -7,8 +7,14 @@ require_relative "data_test/compare"
 require_relative "data_test/verifier"
 require_relative "data_test/uploader"
 require_relative "data_test/fetcher"
-require "aws-sdk-s3"
-require "zip"
+begin
+  require "aws-sdk-s3"
+  require "zip"
+rescue LoadError
+  # We're probably in production, production should not be able to
+  # upload to S3, it's allowed to load this file, but it shouldn't
+  # break.
+end
 
 module DataTest
   # This module is to help get a test flow that uses actual production

--- a/lib/data_test/fetcher.rb
+++ b/lib/data_test/fetcher.rb
@@ -25,6 +25,7 @@ module DataTest
 
     def self.can_run?
       return false unless !!S3_REGION
+      return false unless defined?(Aws)
       new.can_run?
     end
 

--- a/lib/data_test/uploader.rb
+++ b/lib/data_test/uploader.rb
@@ -25,6 +25,8 @@ module DataTest
 
     def self.can_run?
       return false unless !!S3_REGION
+      return false unless defined?(Aws)
+
       new.can_run?
     end
 


### PR DESCRIPTION
The rake task requires it so it gets loaded, since datatest is
requiring `aws-sdk-s3` for fetching and uploading, and this gem is
only installed in development/test, on production it would break.

Heroku runs into this when trying to detect rake tasks:

     Could not detect rake tasks
      !     ensure you can run `$ bundle exec rake -P` against your app
      !     and using the production group of your Gemfile.
      !     rake aborted!
      !     LoadError: cannot load such file -- aws-sdk-s3

This makes it loadable but fetching and uploading won't be
available (and they shouldn't be!)

## Self proof reading checklist

- [x] Did I run Pronto and fixed all warnings (pronto run -c origin/dev)
- [x] Make sure all naming and code will remain understandable in 6 month by someone new to the project or by you.
- [x] Did I test the right thing?
- [x] Did I test corner cases, non happy path (defensive testing)?
- [x] Check that I used the ad-hoc patterns and created files accordingly (Presenters, Services, Search object, Form object,...)
- [x] Check code efficiency with record intensive project
- [x] Update documentation,readme accordingly

Thanks!
