### PR TITLE
Add values mocking for current_quarter and time window _values

### DIFF
--- a/app/models/rule_types/activity_rule_type.rb
+++ b/app/models/rule_types/activity_rule_type.rb
@@ -21,7 +21,6 @@ module RuleTypes
       var_names.push("quarter_of_year")
       var_names.push("month_of_year")
       var_names.push("month_of_quarter")
-
       if project.new_engine? && package.package_rule
         var_names.push(*package.package_rule.formulas.map(&:code))
       end
@@ -57,6 +56,7 @@ module RuleTypes
             var_names.push(*monthly_vars)
           end
         end
+
         if package.quarterly?
           (1..4).each do |i|
             quarterly_vars = activity_level_states.each_with_object([]) do |formula, result|

--- a/app/services/rules/solver.rb
+++ b/app/services/rules/solver.rb
@@ -33,7 +33,10 @@ module Rules
 
     def validate_expression(formula)
       calculator.dependencies(
-        Rules::ValuesMocker.mock_values(formula.expression, formula.rule.available_variables_for_values)
+        Rules::ValuesMocker.mock_values(
+          formula.expression,
+          formula.rule.available_variables_for_values
+        )
       )
     rescue KeyError => e
       formula.errors[:expression] << "#{e.message}. " \
@@ -45,7 +48,10 @@ module Rules
 
     def dependencies(formula)
       calculator.dependencies(
-        Rules::ValuesMocker.mock_values(formula.expression, formula.rule.available_variables_for_values)
+        Rules::ValuesMocker.mock_values(
+          formula.expression,
+          formula.rule.available_variables_for_values
+        )
       )
     rescue StandardError => ignored
       []
@@ -56,7 +62,10 @@ module Rules
 
       facts = {}.merge(rule.fake_facts)
       rule.formulas.each do |formula|
-        facts[formula.code] = Rules::ValuesMocker.mock_values(formula.expression, rule.available_variables_for_values)
+        facts[formula.code] = Rules::ValuesMocker.mock_values(
+          formula.expression,
+          rule.available_variables_for_values
+        )
       end
       facts[:actictity_rule_name] = Solver.escape_string(rule.name)
       solve!("validate_all_formulas", facts)
@@ -78,6 +87,5 @@ module Rules
     def log(message)
       Rails.logger.info message
     end
-
   end
 end

--- a/app/services/rules/solver.rb
+++ b/app/services/rules/solver.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "dentaku"
 require "dentaku/calculator"
 
@@ -31,7 +33,7 @@ module Rules
 
     def validate_expression(formula)
       calculator.dependencies(
-        mock_values(formula.expression, formula.rule.available_variables_for_values)
+        Rules::ValuesMocker.mock_values(formula.expression, formula.rule.available_variables_for_values)
       )
     rescue KeyError => e
       formula.errors[:expression] << "#{e.message}. " \
@@ -43,7 +45,7 @@ module Rules
 
     def dependencies(formula)
       calculator.dependencies(
-        mock_values(formula.expression, formula.rule.available_variables_for_values)
+        Rules::ValuesMocker.mock_values(formula.expression, formula.rule.available_variables_for_values)
       )
     rescue StandardError => ignored
       []
@@ -51,18 +53,19 @@ module Rules
 
     def validate_formulas(rule)
       return if rule.formulas.empty?
+
       facts = {}.merge(rule.fake_facts)
       rule.formulas.each do |formula|
-        facts[formula.code] = mock_values(formula.expression, rule.available_variables_for_values)
+        facts[formula.code] = Rules::ValuesMocker.mock_values(formula.expression, rule.available_variables_for_values)
       end
       facts[:actictity_rule_name] = Solver.escape_string(rule.name)
-
       solve!("validate_all_formulas", facts)
     rescue Rules::SolvingError => e
       rule.errors[:formulas] << e.original_message
     rescue KeyError => e
       rule.errors[:formulas] << "#{e.message}. Remove extra spaces or verify it's in the available variables"
     rescue StandardError => e
+      log(e.message)
       rule.errors[:formulas] << e.message
     end
 
@@ -76,17 +79,5 @@ module Rules
       Rails.logger.info message
     end
 
-    def mock_values(expression, available_variables_for_values)
-      variables = {}
-      available_variables_for_values
-        .select { |name| name.ends_with?("_values") }
-        .each do |variable_name|
-          raise "please don't add extra spaces in '%{#{variable_name}}'" if variable_name.include?(" ")
-          variables[variable_name.to_sym] = "1 , 2"
-        end
-      expression % variables
-    rescue ArgumentError => e
-      raise e.message
-    end
   end
 end

--- a/app/services/rules/values_mocker.rb
+++ b/app/services/rules/values_mocker.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+module Rules
+  class ValuesMocker
+    def self.build_mock_values(expression, available_variables_for_values)
+      variables = {}
+      available_variables_for_values
+        .select { |name| name.ends_with?("_values") }
+        .each do |variable_name|
+          raise "please don't add extra spaces in '%{#{variable_name}}'" if variable_name.include?(" ")
+          next unless expression.include?(variable_name)
+
+          variables[variable_name.to_sym] = mock_array(variable_name)
+        end
+      variables
+      end
+
+    def self.mock_array(variable_name)
+      if variable_name.end_with?("_current_quarter_values")
+        "1 , 2 , 3"
+      else
+        matched_window = variable_name.match(/.last_(?<length>\d)_(month|quarter)s_window_values/)
+        if matched_window
+          range = 1..(Integer(matched_window[:length]))
+          range.map(&:to_s).join(" , ")
+        else
+          "1 , 2"
+        end
+      end
+    end
+
+    def self.mock_values(expression, available_variables_for_values)
+      variables = build_mock_values(expression, available_variables_for_values)
+      expression % variables
+    rescue ArgumentError => e
+      raise e.message
+    end
+  end
+end

--- a/app/services/rules/values_mocker.rb
+++ b/app/services/rules/values_mocker.rb
@@ -13,20 +13,17 @@ module Rules
           variables[variable_name.to_sym] = mock_array(variable_name)
         end
       variables
-      end
+    end
 
     def self.mock_array(variable_name)
+      length = 2
       if variable_name.end_with?("_current_quarter_values")
-        "1 , 2 , 3"
+        length = 3
       else
         matched_window = variable_name.match(/.last_(?<length>\d)_(month|quarter)s_window_values/)
-        if matched_window
-          range = 1..(Integer(matched_window[:length]))
-          range.map(&:to_s).join(" , ")
-        else
-          "1 , 2"
-        end
+        length = Integer(matched_window[:length]) if matched_window
       end
+      (1..length).map(&:to_s).join(" , ")
     end
 
     def self.mock_values(expression, available_variables_for_values)

--- a/spec/services/rules/solver_spec.rb
+++ b/spec/services/rules/solver_spec.rb
@@ -1,30 +1,47 @@
+# frozen_string_literal: true
 
 require "rails_helper"
 
-RSpec.describe Rules::Solver, type: :services do
-  let(:solver) { Rules::Solver.new }
-
-  describe "mock_values"
-  it "should mock for this expression" do
-    expect(solver.send(
-             :mock_values,
+RSpec.describe Rules::ValuesMocker, type: :services do
+  it "substitute %{_values} with a '1, 2' for double occurance" do
+    expect(Rules::ValuesMocker.mock_values(
              "SUM(%{attributed_points_values})/SUM(%{max_points_values}) * 100.0",
              %w[attributed_points_values max_points_values]
-    )).to eq "SUM(1 , 2)/SUM(1 , 2) * 100.0"
+           )).to eq "SUM(1 , 2)/SUM(1 , 2) * 100.0"
   end
 
-  it "should mock for this expression" do
-    expect(solver.send(
-             :mock_values,
+  it "substitute %{_values} with a '1, 2' for single occurance" do
+    expect(Rules::ValuesMocker.mock_values(
              "SUM(4,6) /SUM(%{max_points_values}) * 100.0",
              ["max_points_values"]
-    )).to eq "SUM(4,6) /SUM(1 , 2) * 100.0"
+           )).to eq "SUM(4,6) /SUM(1 , 2) * 100.0"
   end
 
-  it "should mock_values" do
-    expect(solver.send(
-             :mock_values,
+  it "leave expression untouched if no %{_values}" do
+    expect(Rules::ValuesMocker.mock_values(
              "SUM(1, 7) * 100.0", []
-    )).to eq "SUM(1, 7) * 100.0"
+           )).to eq "SUM(1, 7) * 100.0"
   end
+
+  it "substitute %{last_x_quarters_window_values} with a correct size equations" do
+    expect(Rules::ValuesMocker.mock_values(
+             "SUM(4,6) /SUM(%{demo_last_3_quarters_window_values}) * 100.0",
+             ["demo_last_3_quarters_window_values"]
+           )).to eq "SUM(4,6) /SUM(1 , 2 , 3) * 100.0"
+  end
+
+  it "substitute %{last_x_months_window_values} with a correct size equations" do
+    expect(Rules::ValuesMocker.mock_values(
+             "SUM(4,6) /SUM(%{demo_last_7_months_window_values}) * 100.0",
+             ["demo_last_7_months_window_values"]
+           )).to eq "SUM(4,6) /SUM(1 , 2 , 3 , 4 , 5 , 6 , 7) * 100.0"
+  end
+
+  it "substitute %{_current_quarter_values} with a correct size equations" do
+    expect(Rules::ValuesMocker.mock_values(
+             "SUM(4,6) / SUM(%{demo_current_quarter_values}) * 100.0",
+             ["demo_current_quarter_values"]
+           )).to eq "SUM(4,6) / SUM(1 , 2 , 3) * 100.0"
+  end
+
 end


### PR DESCRIPTION
this kind of formula was not editable because the mocked values used to verify the coherence between formulas were not in the "expected" length.

```
sum(
   eval_array(
              'last_months_values_null_e',  ARRAY(%{method_patient_active_is_null_last_3_months_window_values}),
              'earliest_month_check',     ARRAY(1,0,0),
              'if( earliest_month_check == 1 AND last_months_values_null_e == 0, 1 , 0)'
             )
  )
```

ending with error message

```
Formulas EVAL_ARRAY() requires 'last_months_nulls' and 'earliest_month_check' in (if( earliest_month_check == 1 AND last_months_nulls == 0, 1 , 0)) to have same size of values 
```

because the formula "tested" was 
```
sum(
  eval_array(
           'last_months_nulls',  ARRAY(1 , 2),
          'earliest_month_check',     ARRAY(1,0,0),
          'if( earliest_month_check == 1 AND last_months_nulls == 0, 1 , 0)'
   ) 
)
```
this PR try to make the mock_values more accurate in length depending on expression used (last_x_..._window_values, current_quarter).

