### PR TITLE
Allow a user to select org units before simulation

### DIFF
--- a/app/views/setup/invoices/_form.html.erb
+++ b/app/views/setup/invoices/_form.html.erb
@@ -30,8 +30,47 @@
       <%= f.input :engine_version, collection: @current_project.engine_version_enum %>
     </div>
   </div>
-  <%= f.input :mock_values, as: :boolean%>
-  <%= f.input :with_details, as: :boolean, label: "With details (dhis2 input/output values, equations)"%>
+
+  <h5>Advanced</h5>
+  <div>
+    <div class="form-check row">
+      <div class="col-sm-2">
+        <label class="form-check-label col-form-label">
+          Mock Values
+        </label>
+      </div>
+
+      <div class="col-sm-10">
+        <%= f.input_field :mock_values, as: :boolean, class: "form-check-input" %>
+      </div>
+    </div>
+
+    <div class="form-check row">
+      <div class="col-sm-2">
+        <label class="form-check-label col-form-label">
+          With details
+        </label>
+      </div>
+      <div class="col-sm-10">
+        <%= f.input_field :with_details, as: :boolean, class: "form-check-input" %>
+        <small class="form-text text-muted">
+          (DHIS2 input/output values, equations)
+        </small>
+      </div>
+    </div>
+
+    <div class="form-group row">
+      <label class="string col-sm-2 col-form-label">Selected org units</label>
+      <div class="col-sm-10">
+        <%= text_field_tag "selected_org_units", params[:selected_org_units], class: "form-control" %>
+        <small class="form-text text-muted">
+          A comma separated listed of org unit ids, these will be the only ones shown in the result. If left blank, all org units will be available.
+        </small>
+      </div>
+    </div>
+  </div>
+
+
 
   <%= f.submit 'Push to dhis2',
   name: 'push_to_dhis2',

--- a/app/views/setup/invoices/new_invoice.html.erb
+++ b/app/views/setup/invoices/new_invoice.html.erb
@@ -10,10 +10,20 @@
   See in current situation in dhis2 : <%= link_to_debug_orgunit(@current_project, invoicing_request.entity)%>
   <br>
   <button class="pull-right btn btn-default" onclick="copyToClipboard('#invoice-url')">Copy to clipboard this invoice url <i class="fa fa-copy"></i></button>
-   <span id="invoice-url" class="hidden"><%= new_setup_project_invoice_url(entity: invoicing_request.entity, year: invoicing_request.year, quarter: invoicing_request.quarter) %></span>
+  <span id="invoice-url" class="hidden">
+    <% url_params = {
+      entity: invoicing_request.entity,
+      year: invoicing_request.year,
+      quarter: invoicing_request.quarter
+    } %>
+    <% url_params = url_params.merge(@org_unit_limiter.to_param) %>
+
+    <%= new_setup_project_invoice_url(url_params) %>
+  </span>
   <br>
   <br>
 <%end%>
+
 <button class="pull-right btn btn-default" onclick="copyToClipboard('#rules-descriptors')"><i class="fa fa-copy"></i></button>
 <button class="pull-right btn btn-default" data-toggle="collapse" data-target="#rules-descriptors">Show descriptors</button>
 <div id="rules-descriptors" class="collapse">
@@ -22,6 +32,9 @@
 
 <% periods = invoicing_request.invoices.map(&:period).uniq.sort%>
 <% orgunits = invoicing_request.invoices.map(&:orgunit_ext_id).uniq.map {|id|  @pyramid.org_unit(id) }.map {|ou| [ou.name, ou.ext_id]}.to_h%>
+<% if @org_unit_limiter.active? %>
+  <% orgunits = orgunits.select { |_name, ext_id| @org_unit_limiter.has_org_unit?(ext_id) } %>
+<% end %>
 <% codes = invoicing_request.invoices.map {|invoice| invoice.package&.code || invoice.payment_rule&.code}.uniq.sort.map {|code| [code.humanize, code]}%>
 <br>
 <br>
@@ -42,6 +55,9 @@
                       "data-placeholder" => "Pick orgunits",
                          "data-selection" => "selected-orgunits"}%>
      <div id="selected-orgunits" ></div>
+     <% if @org_unit_limiter.active? %>
+       <small><strong>Note:</strong>You're currently actively limiting the org units, if you didn't expect this, you'll need to clear 'Selected org units'</small>
+     <% end %>
    </div>
    <div class="col-md-4">
    <label>Package or Payment rule (<%= codes.size %>)</label>
@@ -78,8 +94,14 @@
 <% end %>
 
 <h1> Invoice details </h1>
-<%= render partial: "new_invoice", collection: invoicing_request.invoices, :as => :invoice  %>
 
+<% if @org_unit_limiter.active? %>
+  <% selected_invoices = invoicing_request.invoices.select{ |invoice| @org_unit_limiter.has_org_unit?(invoice.orgunit_ext_id) } %>
+<% else %>
+  <% selected_invoices = invoicing_request.invoices %>
+<% end %>
+
+<%= render partial: "new_invoice", collection: selected_invoices, :as => :invoice  %>
 <br>
 <br>
 <br>


### PR DESCRIPTION
Some of our simulations loaded so many org units, which loaded so many tables that the view rendering took to long and ran over the Heroku request. To solve this we're doing two things:

- Make the view rendering async (coming to another PR)
- Allow user to select which org units to simulate (this PR)

![screenshot 2019-02-27 at 16 23 34](https://user-images.githubusercontent.com/52989/53502799-1820c780-3aaf-11e9-9882-708a9e23f76b.png)

![screenshot 2019-02-27 at 16 22 23](https://user-images.githubusercontent.com/52989/53502813-1eaf3f00-3aaf-11e9-8534-16f4ee0a898b.png)

### Few things to note:

- Copying URL, will include the selected org units
- If left blank all org units will be returned
- Views have been slightly tweaked to make it clear to user.

### Things I'm not sure about

The location of the `OrgUnitLimiter` source. On the one hand, I like that it's only in the Controller. On
the other hand I'm not that much a fan of stowing it in the controller.

It's somewhere between Presenter, ViewModel and Service