### PR TITLE
Add Pry as a dev dependency

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -86,6 +86,11 @@ end
 gem "typhoeus", "~> 1.3.1"
 group :development, :test do
   gem "byebug", platform: :mri
+
+  # Use pry instead of irb: http://pryrepl.org
+  gem "pry", "~> 0.12.2"
+  gem "pry-rails", "~> 0.3.9"
+
   gem "database_cleaner"
   gem "factory_bot_rails", "~> 4.11.1"
   gem "faker"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -121,6 +121,7 @@ GEM
     childprocess (0.9.0)
       ffi (~> 1.0, >= 1.0.11)
     cocoon (1.2.12)
+    coderay (1.1.2)
     coffee-rails (4.2.2)
       coffee-script (>= 2.2.0)
       railties (>= 4.0.0)
@@ -295,6 +296,11 @@ GEM
     pronto-simplecov (0.1.1)
       pronto (~> 0.9.0)
       simplecov
+    pry (0.12.2)
+      coderay (~> 1.1.0)
+      method_source (~> 0.9.0)
+    pry-rails (0.3.9)
+      pry (>= 0.10.4)
     public_suffix (3.0.3)
     puma (3.12.0)
     rack (2.0.6)
@@ -553,6 +559,8 @@ DEPENDENCIES
   pronto-flay
   pronto-rubocop
   pronto-simplecov
+  pry (~> 0.12.2)
+  pry-rails (~> 0.3.9)
   puma (~> 3.0)
   rack (>= 2.0.6)
   rack-mini-profiler


### PR DESCRIPTION
I keep readding it while developing only to remove it when committing, so now is as good a time as any to make it more permanent.

Why?

Glad you asked, the main reasons are:

- Source code highlighting
- `cd` into objects, `ls` in objects to view their methods
- `$ some_method` shows the source of the method
- `. some_shell_command` will run the shell command
- `e Thing#thing` will open an editor with the Thing#Thing opened, I use this a lot to view Rails internals.

It has a lot of other features, but those I use less.