### PR TITLE
Handle passwords with HTML escaped chars

### DIFF
--- a/lib/parallel_dhis2.rb
+++ b/lib/parallel_dhis2.rb
@@ -126,7 +126,7 @@ class ParallelDhis2
     end
 
     def password
-      base_uri.password
+      CGI.unescape(base_uri.password)
     end
 
     def url

--- a/spec/lib/parallel_dhis2_spec.rb
+++ b/spec/lib/parallel_dhis2_spec.rb
@@ -251,9 +251,17 @@ RSpec.describe ParallelDhis2 do
       expect(client.user).to eq("admin")
     end
 
-    it "#password" do
-      client = described_class.new(dhis2_client)
-      expect(client.password).to eq("district")
+    describe "#password" do
+      it "handles normal ones" do
+        client = described_class.new(dhis2_client)
+        expect(client.password).to eq("district")
+      end
+
+      it "with html entities in it" do
+        weird_chars_password = "&*/\d"
+        client = described_class.new(dhis2_client(password: weird_chars_password))
+        expect(client.password).to eq(weird_chars_password)
+      end
     end
 
     describe "#url" do


### PR DESCRIPTION
Ran into this in production, if the password contains some characters that are not allowed in the URL (so they get HTML escaped), `ParallelDhis2` would simply use the escaped version (which was not the correct password).

## Self proof reading checklist

- [x] Did I run Pronto and fixed all warnings (pronto run -c origin/dev)
- [x] Make sure all naming and code will remain understandable in 6 month by someone new to the project or by you.
- [x] Did I test the right thing?
- [x] Did I test corner cases, non happy path (defensive testing)?
- [x] Check that I used the ad-hoc patterns and created files accordingly (Presenters, Services, Search object, Form object,...)
- [x] Check code efficiency with record intensive project
- [x] Update documentation,readme accordingly

Thanks!
