### PR TITLE
Allow to include main orgunit as target in zone package

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -79,8 +79,7 @@ else
   # We're using both of them against the latest master. We should set
   # them to versions when they become more stable
   gem "hesabu", github: "BLSQ/hesabu"
-  #TODO MERGE https://github.com/BLSQ/orbf-rules_engine/pull/46 and restore to master
-  gem "orbf-rules_engine", github: "BLSQ/orbf-rules_engine", branch: "contract-groups-for-zone"
+  gem "orbf-rules_engine", github: "BLSQ/orbf-rules_engine"
 end
 # Like a modern code version of the mythical beast with 100 serpent hea...
 # [typhoeus](https://github.com/typhoeus/typhoeus)

--- a/Gemfile
+++ b/Gemfile
@@ -79,7 +79,8 @@ else
   # We're using both of them against the latest master. We should set
   # them to versions when they become more stable
   gem "hesabu", github: "BLSQ/hesabu"
-  gem "orbf-rules_engine", github: "BLSQ/orbf-rules_engine"
+  #TODO MERGE https://github.com/BLSQ/orbf-rules_engine/pull/46 and restore to master
+  gem "orbf-rules_engine", github: "BLSQ/orbf-rules_engine", branch: "contract-groups-for-zone"
 end
 # Like a modern code version of the mythical beast with 100 serpent hea...
 # [typhoeus](https://github.com/typhoeus/typhoeus)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -14,7 +14,8 @@ GIT
 
 GIT
   remote: https://github.com/BLSQ/orbf-rules_engine.git
-  revision: b3a62f239d84b094a371321583a74bf5e3a1cfb8
+  revision: d0ca39017983f2cfc83c6941b90cd44616b406fb
+  branch: contract-groups-for-zone
   specs:
     orbf-rules_engine (0.1.0)
       activesupport
@@ -130,7 +131,7 @@ GEM
       execjs
     coffee-script-source (1.12.2)
     colorize (0.8.1)
-    concurrent-ruby (1.1.4)
+    concurrent-ruby (1.1.5)
     connection_pool (2.2.2)
     crack (0.4.3)
       safe_yaml (~> 1.0.0)
@@ -202,7 +203,7 @@ GEM
     httparty (0.16.3)
       mime-types (~> 3.0)
       multi_xml (>= 0.5.2)
-    i18n (1.5.3)
+    i18n (1.6.0)
       concurrent-ruby (~> 1.0)
     immigrant (0.3.6)
       activerecord (>= 3.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -14,8 +14,7 @@ GIT
 
 GIT
   remote: https://github.com/BLSQ/orbf-rules_engine.git
-  revision: d0ca39017983f2cfc83c6941b90cd44616b406fb
-  branch: contract-groups-for-zone
+  revision: 584b7f70eeeb74c16c5a720d0b52f74c65f9a1ff
   specs:
     orbf-rules_engine (0.1.0)
       activesupport

--- a/app/controllers/setup/packages_controller.rb
+++ b/app/controllers/setup/packages_controller.rb
@@ -84,7 +84,7 @@ class Setup::PackagesController < PrivateController
 
   def params_package
     params.require(:package).permit(
-      :name, :frequency, :kind, :ogs_reference,
+      :name, :frequency, :kind, :ogs_reference, :include_main_orgunit,
       state_ids: [], activity_ids: [], groupsets_ext_refs: []
     )
   end

--- a/app/models/package.rb
+++ b/app/models/package.rb
@@ -7,6 +7,7 @@
 #  data_element_group_ext_ref :string           not null
 #  frequency                  :string           not null
 #  groupsets_ext_refs         :string           default([]), is an Array
+#  include_main_orgunit       :boolean          default(FALSE), not null
 #  kind                       :string           default("single")
 #  name                       :string           not null
 #  ogs_reference              :string

--- a/app/services/map_project_to_orbf_project.rb
+++ b/app/services/map_project_to_orbf_project.rb
@@ -52,7 +52,8 @@ class MapProjectToOrbfProject
       matching_groupset_ext_ids:     package.groupsets_ext_refs,
       dataset_ext_ids:               package.package_states.map(&:ds_external_reference).compact,
       activities:                    map_activities(package.activities, package.states),
-      rules:                         map_rules(package.rules)
+      rules:                         map_rules(package.rules),
+      include_main_orgunit:          package.include_main_orgunit
     )
   end
 

--- a/app/views/setup/packages/_form.html.erb
+++ b/app/views/setup/packages/_form.html.erb
@@ -59,7 +59,9 @@
 </div>
   <div class="col-md-6" id="target_entity_groups_selection"></div>
 </div>
-
+<%= f.label :include_main_orgunit %>
+<%= f.input :include_main_orgunit %>
+<%= f.hint "For zone packages, check this one to include the main orgunit also as target for the package and specified the 'Multiple entity by contract group belonging to groupset?'" %>
 
 <%= f.association :states, collection: package.project.states, as: :check_boxes %>
 

--- a/db/migrate/20190314135553_add_include_main_orgunit_to_packages.rb
+++ b/db/migrate/20190314135553_add_include_main_orgunit_to_packages.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddIncludeMainOrgunitToPackages < ActiveRecord::Migration[5.2]
+  def change
+    add_column :packages, :include_main_orgunit, :boolean, default: false, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_02_14_095526) do
+ActiveRecord::Schema.define(version: 2019_03_14_135553) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -203,6 +203,7 @@ ActiveRecord::Schema.define(version: 2019_02_14_095526) do
     t.string "kind", default: "single"
     t.string "ogs_reference"
     t.string "groupsets_ext_refs", default: [], array: true
+    t.boolean "include_main_orgunit", default: false, null: false
     t.index ["project_id"], name: "index_packages_on_project_id"
   end
 
@@ -257,9 +258,9 @@ ActiveRecord::Schema.define(version: 2019_02_14_095526) do
     t.integer "original_id"
     t.string "cycle", default: "quarterly", null: false
     t.integer "engine_version", default: 1, null: false
-    t.string "qualifier"
     t.string "default_coc_reference"
     t.string "default_aoc_reference"
+    t.string "qualifier"
     t.index ["project_anchor_id"], name: "index_projects_on_project_anchor_id"
   end
 

--- a/spec/controllers/setup/packages_controller_spec.rb
+++ b/spec/controllers/setup/packages_controller_spec.rb
@@ -61,30 +61,30 @@ RSpec.describe Setup::PackagesController, type: :controller do
         "project_id"    => project.id,
         "data_elements" => { project.state(:tarif).id.to_s => { external_reference: "FTRrcoaog83" } },
         "package"       => {
-          "name"               => "azeaze",
-          "state_ids"          => state_ids,
-          "frequency"          => "monthly",
-          "main_entity_groups"      => ["entityid1"],
-          "target_entity_groups"      => [],
-          "groupsets_ext_refs" => %w[groupsets_ext_ref1 groupsets_ext_ref2]
+          "name"                 => "azeaze",
+          "state_ids"            => state_ids,
+          "frequency"            => "monthly",
+          "main_entity_groups"   => ["entityid1"],
+          "target_entity_groups" => [],
+          "groupsets_ext_refs"   => %w[groupsets_ext_ref1 groupsets_ext_ref2]
         }
       }
 
       package = assigns(:package)
 
-      groups_set_refs = ["sample_groupset_ext", "other_groupset_ext"]
+      groups_set_refs = %w[sample_groupset_ext other_groupset_ext]
 
       post :update, params: {
         "project_id"    => project.id,
-        "id" => package.id,
+        "id"            => package.id,
         "data_elements" => { project.state(:tarif).id.to_s => { external_reference: "FTRrcoaog83" } },
         "package"       => {
-          "name"               => "new name",
-          "state_ids"          => state_ids.slice(0, 2),
-          "frequency"          => "monthly",
-          "main_entity_groups"      => ["entityid1"],
-          "target_entity_groups"      => [],
-          "groupsets_ext_refs" => groups_set_refs
+          "name"                 => "new name",
+          "state_ids"            => state_ids.slice(0, 2),
+          "frequency"            => "monthly",
+          "main_entity_groups"   => ["entityid1"],
+          "target_entity_groups" => [],
+          "groupsets_ext_refs"   => groups_set_refs
         }
       }
 
@@ -116,34 +116,38 @@ RSpec.describe Setup::PackagesController, type: :controller do
         "project_id"    => project.id,
         "data_elements" => { project.state(:tarif).id.to_s => { external_reference: "FTRrcoaog83" } },
         "package"       => {
-          "name"               => "azeaze",
-          "state_ids"          => state_ids,
-          "frequency"          => "monthly",
-          "main_entity_groups"      => ["entityid1"],
-          "target_entity_groups"      => ["sub_entityid1"],
-          "groupsets_ext_refs" => %w[groupsets_ext_ref1 groupsets_ext_ref2]
+          "name"                 => "azeaze",
+          "state_ids"            => state_ids,
+          "frequency"            => "monthly",
+          "main_entity_groups"   => ["entityid1"],
+          "target_entity_groups" => ["sub_entityid1"],
+          "groupsets_ext_refs"   => %w[groupsets_ext_ref1 groupsets_ext_ref2],
+          "include_main_orgunit" => true
         }
       }
 
       package = assigns(:package)
+      expect(package.include_main_orgunit).to eq(true)
 
-      groups_set_refs = ["sample_groupset_ext", "other_groupset_ext"]
+      groups_set_refs = %w[sample_groupset_ext other_groupset_ext]
 
       post :update, params: {
         "project_id"    => project.id,
-        "id" => package.id,
+        "id"            => package.id,
         "data_elements" => { project.state(:tarif).id.to_s => { external_reference: "FTRrcoaog83" } },
         "package"       => {
-          "name"               => "new name",
-          "state_ids"          => state_ids.slice(0, 2),
-          "frequency"          => "monthly",
-          "main_entity_groups"      => ["entityid1"],
-          "target_entity_groups"      => ["sub_entityid1"],
-          "groupsets_ext_refs" => groups_set_refs
+          "name"                 => "new name",
+          "state_ids"            => state_ids.slice(0, 2),
+          "frequency"            => "monthly",
+          "main_entity_groups"   => ["entityid1"],
+          "target_entity_groups" => ["sub_entityid1"],
+          "groupsets_ext_refs"   => groups_set_refs,
+          "include_main_orgunit" => false
         }
       }
 
       package.reload
+      expect(package.include_main_orgunit).to eq(false)
       expect(package.groupsets_ext_refs).to eq(groups_set_refs)
       expect(package.main_entity_groups.map(&:organisation_unit_group_ext_ref)).to eq(["entityid1"])
       expect(package.target_entity_groups.map(&:organisation_unit_group_ext_ref)).to eq(["sub_entityid1"])

--- a/spec/factories/packages.rb
+++ b/spec/factories/packages.rb
@@ -6,6 +6,7 @@
 #  data_element_group_ext_ref :string           not null
 #  frequency                  :string           not null
 #  groupsets_ext_refs         :string           default([]), is an Array
+#  include_main_orgunit       :boolean          default(FALSE), not null
 #  kind                       :string           default("single")
 #  name                       :string           not null
 #  ogs_reference              :string

--- a/spec/lib/data_test_spec.rb
+++ b/spec/lib/data_test_spec.rb
@@ -9,21 +9,21 @@ def result(name)
   JSON.parse(File.open(File.join(DataTest::RESULTS_DIR,name)).read)
 end
 
+if DataTest.has_artefacts?
+  puts "Artefacts found (no new download)"
+else
+  puts "Downloading artefacts"
+  WebMock.allow_net_connect!
+  fetcher = DataTest::Fetcher.new
+  fetcher.fetch_config_file
+  fetcher.fetch_all_artefacts
+  WebMock.disable_net_connect!
+end
+
+raise "should have downloaded the test artefacts" if ENV["CI"] && !DataTest.has_artefacts?
+
 RSpec.describe "Data Test", data_test: true do
   if DataTest::Fetcher.can_run?
-    before(:all) do
-      if DataTest.has_artefacts?
-        puts "Artefacts found (no new download)"
-      else
-        puts "Downloading artefacts"
-        WebMock.allow_net_connect!
-        fetcher = DataTest::Fetcher.new
-        fetcher.fetch_config_file
-        fetcher.fetch_all_artefacts
-        WebMock.disable_net_connect!
-      end
-    end
-
     after(:all) do
       unless DataTest.keep_artefacts?
         puts "Removing config file"

--- a/spec/services/map_project_to_orbf_project_spec.rb
+++ b/spec/services/map_project_to_orbf_project_spec.rb
@@ -43,6 +43,8 @@ RSpec.describe MapProjectToOrbfProject do
 
     orbf_package_formula = orbf_project.packages.last.package_rules.first.formulas.last
     expect(orbf_package_formula.dhis2_mapping).to eq("package_dhis2_out")
+
+    expect(orbf_project.packages.last.include_main_orgunit?).to eq(false)
     # dump with yaml to support circular references
     puts YAML.dump(orbf_project)
   end
@@ -53,6 +55,7 @@ RSpec.describe MapProjectToOrbfProject do
     package = project.packages.build(name: "zone_test", kind: "zone", frequency: "monthly")
     package.package_entity_groups.build(kind: "main", organisation_unit_group_ext_ref: "mainextid")
     package.package_entity_groups.build(kind: "target", organisation_unit_group_ext_ref: "targetextid")
+    package.include_main_orgunit = true
 
     activity1 = project.activities[0]
     activity2 = project.activities[1]
@@ -76,5 +79,6 @@ RSpec.describe MapProjectToOrbfProject do
       activity1.code => "act1",
       activity2.code => "act2"
     )
+    expect(orbf_project.packages.last.include_main_orgunit?).to eq(true)
   end
 end


### PR DESCRIPTION
requires https://github.com/BLSQ/orbf-rules_engine/pull/46

In burundi scheme, we'd like to allow zone packages with "groupset" to allow adding the main orgunit as a target too. To avoid breaking existing behaviour (think Liberia ) a new option has been added to include_main_orgunit or not.

![image](https://user-images.githubusercontent.com/371692/54416387-81374a80-46ff-11e9-911b-c225f13b2375.png)
