### PR TITLE
Add support level x quarterly

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -14,7 +14,7 @@ GIT
 
 GIT
   remote: https://github.com/BLSQ/orbf-rules_engine.git
-  revision: 314bb6242b0e6907034f977f19e33bbc32c064db
+  revision: a56df0718e2a13c34e55247c072e3ec3e4e14931
   specs:
     orbf-rules_engine (0.1.0)
       activesupport

--- a/app/services/analytics/locations/level_scope.rb
+++ b/app/services/analytics/locations/level_scope.rb
@@ -49,10 +49,12 @@ module Analytics
 
       def variable_states(package)
         states = package.states.select(&:activity_level?)
-        vars = (1..5).flat_map do |level|
-          states.map { |state| ["#{state.code}_level_#{level}", state] }
+        (1..5).each_with_object({}) do |level, result|
+          states.each do |state|
+            result["#{state.code}_level_#{level}"]= state
+            result["#{state.code}_level_#{level}_quarterly"]= state
+          end
         end
-        vars.to_h
       end
     end
   end

--- a/app/services/analytics/locations/level_scope.rb
+++ b/app/services/analytics/locations/level_scope.rb
@@ -51,8 +51,8 @@ module Analytics
         states = package.states.select(&:activity_level?)
         (1..5).each_with_object({}) do |level, result|
           states.each do |state|
-            result["#{state.code}_level_#{level}"]= state
-            result["#{state.code}_level_#{level}_quarterly"]= state
+            result["#{state.code}_level_#{level}"] = state
+            result["#{state.code}_level_#{level}_quarterly"] = state
           end
         end
       end

--- a/spec/models/rules_spec.rb
+++ b/spec/models/rules_spec.rb
@@ -151,10 +151,15 @@ RSpec.describe Rule, kind: :model do
       claimed
       claimed_is_null
       claimed_level_1
+      claimed_level_1_quarterly
       claimed_level_2
+      claimed_level_2_quarterly
       claimed_level_3
+      claimed_level_3_quarterly
       claimed_level_4
+      claimed_level_4_quarterly
       claimed_level_5
+      claimed_level_5_quarterly
       difference_percentage
       month_of_quarter
       month_of_year
@@ -163,17 +168,27 @@ RSpec.describe Rule, kind: :model do
       tarif
       tarif_is_null
       tarif_level_1
+      tarif_level_1_quarterly
       tarif_level_2
+      tarif_level_2_quarterly
       tarif_level_3
+      tarif_level_3_quarterly
       tarif_level_4
+      tarif_level_4_quarterly
       tarif_level_5
+      tarif_level_5_quarterly
       verified
       verified_is_null
       verified_level_1
+      verified_level_1_quarterly
       verified_level_2
+      verified_level_2_quarterly
       verified_level_3
+      verified_level_3_quarterly
       verified_level_4
+      verified_level_4_quarterly
       verified_level_5
+      verified_level_5_quarterly
     ].freeze
 
     it "should return all states and scoped states " do
@@ -390,10 +405,15 @@ RSpec.describe Rule, kind: :model do
         claimed
         claimed_is_null
         claimed_level_1
+        claimed_level_1_quarterly
         claimed_level_2
+        claimed_level_2_quarterly
         claimed_level_3
+        claimed_level_3_quarterly
         claimed_level_4
+        claimed_level_4_quarterly
         claimed_level_5
+        claimed_level_5_quarterly
         claimed_zone_main_orgunit
         fosa_attributed_points
         month_of_quarter


### PR DESCRIPTION
this PR bundles the rule engine changes to support ..._level_X_quarterly : https://github.com/BLSQ/orbf-rules_engine/pull/49

this add "auto completetion" in variable edition 
![image](https://user-images.githubusercontent.com/371692/54762153-d25da780-4bf3-11e9-8fa2-93107879c84b.png)

the simulation with the modified formula shows the quaterly value of the parent

![image](https://user-images.githubusercontent.com/371692/54762274-1355bc00-4bf4-11e9-8ed8-3458f46b2a88.png)

TODO : verify legacy engine is not impacted
