### PR TITLE
Devise 4.5.0 -> 4.6.2

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -53,7 +53,9 @@ gem "uglifier", ">= 1.3.0"
 
 ## Authentication
 
-gem "devise", "~> 4.5.0"
+# Flexible authentication solution for Rails with Warden
+# [devise](https://github.com/plataformatec/devise)
+gem "devise", "~> 4.6.2"
 
 ## API related
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -141,7 +141,7 @@ GEM
       activerecord (>= 3.1.0, < 6)
     dentaku (3.1.0)
     descriptive_statistics (2.5.1)
-    devise (4.5.0)
+    devise (4.6.2)
       bcrypt (~> 3.0)
       orm_adapter (~> 0.1)
       railties (>= 4.1.0, < 6.0)
@@ -265,7 +265,7 @@ GEM
     nested_form (0.3.2)
     netrc (0.11.0)
     nio4r (2.3.1)
-    nokogiri (1.10.1)
+    nokogiri (1.10.2)
       mini_portile2 (~> 2.4.0)
     octokit (4.13.0)
       sawyer (~> 0.8.0, >= 0.5.3)
@@ -368,9 +368,9 @@ GEM
     remotipart (1.4.2)
     request_store (1.4.1)
       rack (>= 1.4)
-    responders (2.4.0)
-      actionpack (>= 4.2.0, < 5.3)
-      railties (>= 4.2.0, < 5.3)
+    responders (2.4.1)
+      actionpack (>= 4.2.0, < 6.0)
+      railties (>= 4.2.0, < 6.0)
     rest-client (2.0.2)
       http-cookie (>= 1.0.2, < 2.0)
       mime-types (>= 1.16, < 4.0)
@@ -525,7 +525,7 @@ DEPENDENCIES
   database_cleaner
   deep_cloneable
   dentaku
-  devise (~> 4.5.0)
+  devise (~> 4.6.2)
   dhis2!
   differ
   factory_bot_rails (~> 4.11.1)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -31,7 +31,7 @@
 class User < ApplicationRecord
   # Include default devise modules. Others available are:
   # :confirmable, :lockable, :timeoutable and :omniauthable
-  devise :database_authenticatable, :registerable,
+  devise :database_authenticatable,
          :recoverable, :rememberable, :trackable, :validatable
 
   validates :email,

--- a/app/views/devise/confirmations/new.html.erb
+++ b/app/views/devise/confirmations/new.html.erb
@@ -1,7 +1,7 @@
 <h2>Resend confirmation instructions</h2>
 
 <%= form_for(resource, as: resource_name, url: confirmation_path(resource_name), html: { method: :post }) do |f| %>
-  <%= devise_error_messages! %>
+  <%= render "devise/shared/error_messages", resource: resource %>
 
   <div class="field">
     <%= f.label :email %><br />

--- a/app/views/devise/passwords/edit.html.erb
+++ b/app/views/devise/passwords/edit.html.erb
@@ -1,7 +1,7 @@
 <h2>Change your password</h2>
 
 <%= form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :put }) do |f| %>
-  <%= devise_error_messages! %>
+  <%= render "devise/shared/error_messages", resource: resource %>
   <%= f.hidden_field :reset_password_token %>
 
   <div class="field">

--- a/app/views/devise/passwords/new.html.erb
+++ b/app/views/devise/passwords/new.html.erb
@@ -14,7 +14,7 @@
                 <div class="panel-body">
 
                   <%= form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :post }) do |f| %>
-                    <%= devise_error_messages! %>
+                    <%= render "devise/shared/error_messages", resource: resource %>
 
                     <div class="form-group">
                         <%= f.label :email %><br/>

--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -1,7 +1,7 @@
 <h2>Edit <%= resource_name.to_s.humanize %></h2>
 
 <%= form_for(resource, as: resource_name, url: registration_path(resource_name), html: { method: :put }) do |f| %>
-  <%= devise_error_messages! %>
+  <%= render "devise/shared/error_messages", resource: resource %>
 
   <div class="field">
     <%= f.label :email %><br />

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -13,8 +13,8 @@
                 </div>
                 <div class="panel-body">
 
-                    <%= form_for(resource, as: resource_name, url: registration_path(resource_name)) do |f| %>
-                    <%= devise_error_messages! %>
+                  <%= form_for(resource, as: resource_name, url: registration_path(resource_name)) do |f| %>
+                    <%= render "devise/shared/error_messages", resource: resource %>
 
                     <div class="form-group">
                         <%= f.label :email %><br/>

--- a/app/views/devise/unlocks/new.html.erb
+++ b/app/views/devise/unlocks/new.html.erb
@@ -1,7 +1,7 @@
 <h2>Resend unlock instructions</h2>
 
 <%= form_for(resource, as: resource_name, url: unlock_path(resource_name), html: { method: :post }) do |f| %>
-  <%= devise_error_messages! %>
+  <%= render "devise/shared/error_messages", resource: resource %>
 
   <div class="field">
     <%= f.label :email %><br />


### PR DESCRIPTION
From the Devise Changelog [0]

deprecations:

- The second argument of DatabaseAuthenticatable's #update_with_password and #update_without_password is deprecated and will be removed in the next major version. It was added to support a feature deprecated in Rails 4, so you can safely remove it from your code. (by @ihatov08)
- The DeviseHelper.devise_error_messages! is deprecated and will be removed in the next major version. Use the devise/shared/error_messages partial instead. (by @mracos)

So I've removed the `devise_error_messages!` from our views and
replaced them with the partials. I tried sign up and forgot views. The
others I eyeballed the code.

[0] https://github.com/plataformatec/devise/blob/2e5b5fcd705b06c518ab0156b96badb91c4cb6ea/CHANGELOG.md
