### PR TITLE
fix versioning and drop state levels

### DIFF
--- a/app/controllers/setup/activities_controller.rb
+++ b/app/controllers/setup/activities_controller.rb
@@ -55,7 +55,7 @@ class Setup::ActivitiesController < PrivateController
   private
 
   def activity_level_states
-    current_project.states.where(level: "activity")
+    current_project.states
   end
 
   def handle_action(template)

--- a/app/controllers/setup/project_rules_controller.rb
+++ b/app/controllers/setup/project_rules_controller.rb
@@ -5,9 +5,13 @@ class Setup::ProjectRulesController < PrivateController
   attr_reader :project_rule
 
   def index
-    data_compound = current_project.project_anchor.nearest_data_compound_for(Date.new) || DataCompound.from(current_project)
+
+    project = current_project(
+      raise_if_published: false
+    )
+    data_compound = project.project_anchor.nearest_data_compound_for(Date.new) || DataCompound.from(project)
     @orbf_project = MapProjectToOrbfProject.new(
-      current_project,
+      project,
       data_compound.indicators
     ).map
 

--- a/app/controllers/setup/project_rules_controller.rb
+++ b/app/controllers/setup/project_rules_controller.rb
@@ -5,16 +5,15 @@ class Setup::ProjectRulesController < PrivateController
   attr_reader :project_rule
 
   def index
-
     project = current_project(
       raise_if_published: false
     )
-    data_compound = project.project_anchor.nearest_data_compound_for(Date.new) || DataCompound.from(project)
+    data_compound = project.project_anchor
+                           .nearest_data_compound_for(Date.new) || DataCompound.from(project)
     @orbf_project = MapProjectToOrbfProject.new(
       project,
       data_compound.indicators
     ).map
-
   end
 
   def new

--- a/app/models/decision_table.rb
+++ b/app/models/decision_table.rb
@@ -39,7 +39,7 @@ class DecisionTable < ApplicationRecord
 
   def in_activity_code_exists
     return unless in_headers.include?("activity_code")
-    available_codes = rule.package.activities.map(&:code).compact
+    available_codes = rule.package.activity_packages.map(&:activity).map(&:code).compact
     available_codes.push Decision::Rule::ANY
     invalid_rules = decision_table.rules.reject { |rule| available_codes.include?(rule[HEADER_IN_ACTIVITY_CODE]) }
     invalid_rules.each { |invalid_rule| errors[:content] << "#{invalid_rule.inspect} not in available package codes #{available_codes}!" }

--- a/app/models/package.rb
+++ b/app/models/package.rb
@@ -59,7 +59,7 @@ class Package < ApplicationRecord
   end
 
   def invoice_details
-    states.select(&:activity_level?).map(&:code) + activity_rule.formulas.map(&:code) + ["activity_name"]
+    states.map(&:code) + activity_rule.formulas.map(&:code) + ["activity_name"]
   end
 
   def package_state(state)
@@ -194,7 +194,7 @@ class Package < ApplicationRecord
   def missing_activity_states
     missing_activity_states = {}
     activities.each do |activity|
-      missing_states = states.select(&:activity_level?).map do |state|
+      missing_states = states.map do |state|
         state unless activity.activity_state(state)
       end
       missing_activity_states[activity] = missing_states.reject(&:nil?)

--- a/app/models/package_state.rb
+++ b/app/models/package_state.rb
@@ -30,4 +30,8 @@ class PackageState < ApplicationRecord
   delegate :program_id, to: :package
   belongs_to :package
   belongs_to :state
+
+  def activity_level?
+    state.activity_level?
+  end
 end

--- a/app/models/package_state.rb
+++ b/app/models/package_state.rb
@@ -31,7 +31,4 @@ class PackageState < ApplicationRecord
   belongs_to :package
   belongs_to :state
 
-  def activity_level?
-    state.activity_level?
-  end
 end

--- a/app/models/package_state.rb
+++ b/app/models/package_state.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # == Schema Information
 #
 # Table name: package_states
@@ -30,5 +32,4 @@ class PackageState < ApplicationRecord
   delegate :program_id, to: :package
   belongs_to :package
   belongs_to :state
-
 end

--- a/app/models/rule_types/activity_rule_type.rb
+++ b/app/models/rule_types/activity_rule_type.rb
@@ -14,7 +14,7 @@ module RuleTypes
       var_names = []
 
       if package
-        var_names.push(*package.states.select(&:activity_level?).map(&:code))
+        var_names.push(*package_states.map(&:code))
         var_names.push(*null_states)
       end
       var_names.push(*formulas.map(&:code))
@@ -41,7 +41,7 @@ module RuleTypes
     def available_variables_for_values
       var_names = []
 
-      activity_level_states = package.package_states.map(&:state).select(&:activity_level?)
+      activity_level_states = package_states
       Analytics::Timeframe.all_variables_builders.each do |timeframe|
         var_names.push(*activity_level_states.map { |state| "#{state.code}#{timeframe.suffix}" })
       end
@@ -84,7 +84,7 @@ module RuleTypes
 
     def fake_facts
       # in case we are in a clone packages a not there so go through long road package_states instead of states
-      to_fake_facts(package.package_states.map(&:state).select(&:activity_level?))
+      to_fake_facts(package_states)
         .merge(
           Analytics::Locations::LevelScope.new.to_fake_facts(package)
         )
@@ -98,7 +98,7 @@ module RuleTypes
     private
 
     def main_orgunit_states
-      package.states.select(&:activity_level?).map { |state| "#{state.code}_zone_main_orgunit" }
+      package_states.map { |state| "#{state.code}_zone_main_orgunit" }
     end
 
     def main_orgunit_facts
@@ -108,7 +108,7 @@ module RuleTypes
     end
 
     def null_states
-      package.states.select(&:activity_level?).map { |state| "#{state.code}_is_null" }
+      package_states.map { |state| "#{state.code}_is_null" }
     end
 
     def null_facts

--- a/app/models/rule_types/base_rule_type.rb
+++ b/app/models/rule_types/base_rule_type.rb
@@ -15,7 +15,7 @@ module RuleTypes
     delegate :payment_rule, to: :rule
 
     def package_states
-      package.package_states.select(&:activity_level?).map(&:state)
+      package.package_states.map(&:state)
     end
 
     def to_fake_facts(states)

--- a/app/models/rule_types/base_rule_type.rb
+++ b/app/models/rule_types/base_rule_type.rb
@@ -14,6 +14,10 @@ module RuleTypes
     delegate :decision_tables, to: :rule
     delegate :payment_rule, to: :rule
 
+    def package_states
+      package.package_states.select(&:activity_level?).map(&:state)
+    end
+
     def to_fake_facts(states)
       facts = states.map { |state| [state.code.to_sym, "10"] }.to_h
       facts[:month_of_year] = 6

--- a/app/models/rule_types/multi_entity_rule_type.rb
+++ b/app/models/rule_types/multi_entity_rule_type.rb
@@ -10,7 +10,7 @@ module RuleTypes
 
     def available_variables
       var_names = []
-      var_names << package.states.select(&:activity_level?).map(&:code)
+      var_names << package_states.map(&:code)
       var_names << decision_tables.map(&:out_headers) if decision_tables.any?
       var_names.flatten.uniq.reject(&:nil?).sort
     end
@@ -20,7 +20,7 @@ module RuleTypes
     end
 
     def fake_facts
-      to_fake_facts(package.package_states.map(&:state).select(&:activity_level?))
+      to_fake_facts(package_states)
     end
   end
 end

--- a/app/models/rule_types/package_rule_type.rb
+++ b/app/models/rule_types/package_rule_type.rb
@@ -29,7 +29,6 @@ module RuleTypes
     def available_variables
       var_names = []
 
-      var_names << package.package_states.map(&:state).select(&:package_level?).map(&:code) if package
       var_names << available_variables_for_values.map { |code| "%{#{code}}" }
 
       var_names << package.zone_rule.formulas.map(&:code) if package.zone_rule
@@ -49,7 +48,7 @@ module RuleTypes
 
     def fake_facts
       # in case we are in a clone packages a not there so go through long road package_states instead of package.states
-      to_fake_facts(package.package_states.map(&:state).select(&:package_level?))
+      to_fake_facts([])
         .merge(zone_rule_fake_facts)
     end
 

--- a/app/models/rule_types/package_rule_type.rb
+++ b/app/models/rule_types/package_rule_type.rb
@@ -29,7 +29,7 @@ module RuleTypes
     def available_variables
       var_names = []
 
-      var_names << package.states.select(&:package_level?).map(&:code) if package
+      var_names << package.package_states.map(&:state).select(&:package_level?).map(&:code) if package
       var_names << available_variables_for_values.map { |code| "%{#{code}}" }
 
       var_names << package.zone_rule.formulas.map(&:code) if package.zone_rule

--- a/app/models/rule_types/zone_activity_rule_type.rb
+++ b/app/models/rule_types/zone_activity_rule_type.rb
@@ -25,7 +25,7 @@ module RuleTypes
     end
 
     def fake_facts
-      to_fake_facts(package.package_states.map(&:state)).merge(org_units_count: 1)
+      to_fake_facts(package_states).merge(org_units_count: 1)
     end
   end
 end

--- a/app/models/state.rb
+++ b/app/models/state.rb
@@ -20,6 +20,9 @@
 #
 
 class State < ApplicationRecord
+  include PaperTrailed
+  delegate :program_id, to: :project
+
   validates :name, presence: true
   validates :code, presence: true, format: {
     with:    Formula::REGEXP_VALIDATION,

--- a/app/models/state.rb
+++ b/app/models/state.rb
@@ -3,7 +3,6 @@
 # Table name: states
 #
 #  id         :integer          not null, primary key
-#  level      :string           default("activity"), not null
 #  name       :string           not null
 #  short_name :string
 #  created_at :datetime         not null
@@ -40,14 +39,6 @@ class State < ApplicationRecord
 
   def code
     @code ||= Codifier.codify(name)
-  end
-
-  def package_level?
-    level == "package"
-  end
-
-  def activity_level?
-    level == "activity"
   end
 
   def to_unified_h

--- a/app/services/analytics/locations/level_scope.rb
+++ b/app/services/analytics/locations/level_scope.rb
@@ -48,7 +48,7 @@ module Analytics
       end
 
       def variable_states(package)
-        states = package.package_states.select(&:activity_level?).map(&:state)
+        states = package.package_states.map(&:state)
         (1..5).each_with_object({}) do |level, result|
           states.each do |state|
             result["#{state.code}_level_#{level}"] = state

--- a/app/services/analytics/locations/level_scope.rb
+++ b/app/services/analytics/locations/level_scope.rb
@@ -48,7 +48,7 @@ module Analytics
       end
 
       def variable_states(package)
-        states = package.states.select(&:activity_level?)
+        states = package.package_states.select(&:activity_level?).map(&:state)
         (1..5).each_with_object({}) do |level, result|
           states.each do |state|
             result["#{state.code}_level_#{level}"] = state

--- a/app/services/analytics/multi_entities_calculator.rb
+++ b/app/services/analytics/multi_entities_calculator.rb
@@ -56,7 +56,7 @@ module Analytics
       package.multi_entities_rule.formulas.each do |formula|
         hash[formula.code] = formula.expression
       end
-      package.states.each do |state|
+      package.package_states.map(&:state).each do |state|
         hash[state.code] ||= 0
       end
       solver.solve!("multientities for #{package.name}", hash)

--- a/app/services/analytics/timeframe/previous_year.rb
+++ b/app/services/analytics/timeframe/previous_year.rb
@@ -31,7 +31,7 @@ module Analytics
           variables[activity_state.state.code.to_s + suffix] ||= [0]
         end
 
-        package.states.each do |state|
+        package.package_states.map(&:state).each do |state|
           variables["#{state.code}#{suffix}"] ||= [0]
         end
 

--- a/app/services/project_factory.rb
+++ b/app/services/project_factory.rb
@@ -1,4 +1,3 @@
-# coding: utf-8
 # frozen_string_literal: true
 
 class ProjectFactory
@@ -184,7 +183,7 @@ class ProjectFactory
             ),
             new_formula(
               :performance_amount,
-              "(performance_score_value / 100.0) * budget",
+              "(performance_score_value / 100.0) * 1000",
               "Performance amount"
             )
           ]
@@ -270,20 +269,20 @@ class ProjectFactory
     clinic_group = {   name: "Clinic",         organisation_unit_group_ext_ref: "RXL3lPSK8oG" }
     admin_group = {    name: "Administrative", organisation_unit_group_ext_ref: "w0gFTTmsUcF" }
     project.build_entity_group(
-      name: clinic_group[:name],
+      name:               clinic_group[:name],
       external_reference: clinic_group[:organisation_unit_group_ext_ref]
     )
 
     [
-      { name: "Claimed",           level: "activity" },
-      { name: "Verified",          level: "activity" },
-      { name: "Validated",         level: "activity" },
-      { name: "Max. Score",        level: "activity" },
-      { name: "Tarif",             level: "activity" },
-      { name: "Budget",            level: "package"  },
-      { name: "Remoteness Bonus",  level: "package"  },
-      { name: "Applicable Points", level: "activity" },
-      { name: "Waiver",            level: "activity" }
+      { name: "Claimed"            },
+      { name: "Verified"           },
+      { name: "Validated"          },
+      { name: "Max. Score"         },
+      { name: "Tarif"              },
+      { name: "Budget"              },
+      { name: "Remoteness Bonus"    },
+      { name: "Applicable Points"  },
+      { name: "Waiver"             }
     ].each do |state|
       project.states.build(state)
     end
@@ -329,24 +328,24 @@ class ProjectFactory
   end
 
   # These only get run by the seed controller. Adding them to the normal build operation would break some specs, since these two are not really related, keeping these separate.
-  def additional_seed_actions(project, suffix = "")
+  def additional_seed_actions(project, _suffix = "")
     verified_state = project.states.find { |s| s.name == "Verified" }
     max_state = project.states.find { |s| s.name == "Max. Score" }
 
-    activity_1 = project.activities.detect{|a| a.name == "Vaccination"}
+    activity_1 = project.activities.detect { |a| a.name == "Vaccination" }
     activity_1.activity_states.build(
-      { name: "Verified", state: verified_state, external_reference: 'M62VHgYT2n0'}
+      name: "Verified", state: verified_state, external_reference: "M62VHgYT2n0"
     )
     activity_1.activity_states.build(
-      { name: "Max. Score", state: max_state, external_reference: 'FQ2o8UBlcrS'}
+      name: "Max. Score", state: max_state, external_reference: "FQ2o8UBlcrS"
     )
 
     activity_2 = project.activities.last
     activity_2.activity_states.build(
-      { name: "Verified", state: verified_state, external_reference: 'CecywZWejT3'}
+      name: "Verified", state: verified_state, external_reference: "CecywZWejT3"
     )
     activity_2.activity_states.build(
-      { name: "Max. Score", state: max_state, external_reference: 'bVkFujnp3F2'}
+      name: "Max. Score", state: max_state, external_reference: "bVkFujnp3F2"
     )
 
     # Legacy-engine needs this engine, otherwise it won't propagate
@@ -421,6 +420,7 @@ class ProjectFactory
       package.package_entity_groups[index].assign_attributes(group)
     end
     return if suffix.blank?
+
     created_ged = package.create_data_element_group(activity_ids)
     package.data_element_group_ext_ref = created_ged.id
     package.activities.flat_map(&:activity_states).each_with_index do |activity_state, index|

--- a/app/views/setup/activities/_constant.html.erb
+++ b/app/views/setup/activities/_constant.html.erb
@@ -1,7 +1,6 @@
-
 <tr>
   <td width="50%"><%= f.input :name,  input_html: {value: f.object.name || @activity.name} %></td>
-  <td><%= f.input :state_id , collection: states.where(level: "activity")%></td>
+  <td><%= f.input :state_id , collection: states%></td>
   <td><%= f.input :formula %></td>
   <%= f.hidden_field :kind, value: 'formula' %>
 </tr>

--- a/app/views/setup/packages/_form.html.erb
+++ b/app/views/setup/packages/_form.html.erb
@@ -65,25 +65,6 @@
 
 <%= f.association :states, collection: package.project.states, as: :check_boxes %>
 
-<% package.project.states.where(level: "package").each do |state| %>
-<div class="row">
-    <div class="col-md-6">
-      <div class="form-group">
-        <label class="control-label">Data element for <%= state.name %> (leave empty if not applicable)</label>
-        <select id="data_elements_selector" data-selected="<%=package.package_state(state).try(:de_external_reference) %>"
-           name="data_elements[<%= state.id%>]"
-           data-placeholder="Lookup the data elements here..."
-           data-selection = "data_elements_selection-<%= state.id %>"
-           data-url = "<%= data_elements_setup_project_autocomplete_index_path(f.object.project) %>"
-           class="form-control sol-powered" >
-        </select>
-    </div>
-  </div>
-  <div class="col-md-6">
-     <div class="col-md-12" id="data_elements_selection-<%= state.id %>"></div>
-  </div>
-</div>
-<%end%>
 <%= f.association :activities, collection: package.project.activities.sort {|a,b| NaturalSort.comparator(a.code, b.code)},
  input_html: {class: 'sol-powered', data: { selection:"activities_selection", selected: package.project.activities.map(&:id)}} %>
 <div id="activities_selection">

--- a/app/views/setup/project_rules/_rule.html.erb
+++ b/app/views/setup/project_rules/_rule.html.erb
@@ -6,7 +6,7 @@
      </tr>
    </thead>
    <tbody>
-    <%rule.formulas.each do|formula|%>
+    <%rule.formulas.sort_by(&:code).each do|formula|%>
       <tr>
         <td ><%= formula.code%>
             <br>&nbsp;&nbsp;<i><%=formula.short_name%></i>

--- a/app/views/setup/setup/_readonly.html.erb
+++ b/app/views/setup/setup/_readonly.html.erb
@@ -6,7 +6,43 @@
 <li>DHIS2 : <%= project.dhis2_url %>
 <li>Contracted entities group : <%= project.entity_group.name %> (<%= project.entity_group.external_reference %>)
 
-<h2>Packages </h2>
+<h2>States (<%= project.states.size%>)</h2>
+<% project.states.each do |state| %>
+  <li><%= state.name%> - <%= state.id%>
+<%end%>
+
+<h2>Activities (<%= project.activities.size%>)</h2>
+
+<table class="table table-striped table-condensed">
+      <thead>
+          <tr>
+            <th width="20%">Activity</th>
+            <th width="25%">Data elements</th>
+            <th width="35%">Packages</th>
+          </tr>
+      </thead>
+      <body>
+          <% project.activities.sort {|a,b| NaturalSort.comparator(a.code, b.code)}.each do |activity| %>
+          <tr>
+            <td><%= activity.name%> <br><small><%= activity.code %></small><br><%= activity.id%> </td>
+            <td>
+                <small>
+                <% activity.activity_states.each do |activity_state| %>
+                    <li><%= activity_state.name %> (<%= activity_state.state.name %> - <%= activity_state.kind %> <%= activity_state.formula? ? "- #{activity_state.formula}" : ""%>  - <%= activity_state.external_reference %> )</li>
+                <% end %>
+                </small>
+            </td>
+            <td>
+            <% activity.activity_packages.map(&:package).each do |pac| %>
+                <li><%= pac.name %> - <%= pac.id %> - <%= pac.project.id%></li>
+            <%end%>
+            </td>
+          </tr>
+        <%end%>
+      </body>
+  </table>
+
+<h2>Packages (<%= project.packages.size%>)</h2>
 <table class="table table-striped table-condensed">
     <thead>
         <tr>

--- a/app/views/setup/setup/index.html.erb
+++ b/app/views/setup/setup/index.html.erb
@@ -1,6 +1,10 @@
 <% if project.draft? %>
 <h1>Let's setup your Project</h1>
+<%if params[:readonly]%>
+<%= render "readonly" %>
+<%else%>
 <%= render partial: "setup/setup/step", collection: setup.steps, locals: { readonly: false }%>
+<%end%>
 <% else %>
 <h1>This project is in readonly</h1>
 <%= link_to "Latest project draft is available here", setup_project_path(current_program.project_anchor.latest_draft) %>

--- a/db/migrate/20190416082904_remove_level_on_states.rb
+++ b/db/migrate/20190416082904_remove_level_on_states.rb
@@ -1,0 +1,5 @@
+class RemoveLevelOnStates < ActiveRecord::Migration[5.2]
+  def change
+    remove_column :states, :level
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_03_28_135206) do
+ActiveRecord::Schema.define(version: 2019_04_16_082904) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_stat_statements"
@@ -303,7 +303,6 @@ ActiveRecord::Schema.define(version: 2019_03_28_135206) do
     t.string "name", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.string "level", default: "activity", null: false
     t.integer "project_id", null: false
     t.string "short_name"
     t.index ["project_id", "name"], name: "index_states_on_project_id_and_name", unique: true

--- a/spec/controllers/setup/activities_controller_spec.rb
+++ b/spec/controllers/setup/activities_controller_spec.rb
@@ -32,7 +32,10 @@ RSpec.describe Setup::ActivitiesController, type: :controller do
       get :edit, params: { project_id: project.id, id: project.activities.first.id }
       activity = assigns(:activity)
       states = assigns(:states)
-      expect(states.map(&:code)).to eq %w[claimed verified validated max_score tarif applicable_points waiver]
+      expect(states.map(&:code)).to eq %w[
+        claimed verified validated max_score
+        tarif budget remoteness_bonus applicable_points waiver
+      ]
       expect(activity).to eq project.activities.first
     end
 

--- a/spec/controllers/setup/project_rules_controller_spec.rb
+++ b/spec/controllers/setup/project_rules_controller_spec.rb
@@ -35,7 +35,8 @@ RSpec.describe Setup::ProjectRulesController, type: :controller do
     end
 
     describe "#index" do
-      it "should render new edit form" do
+      it "should render new documentation for published" do
+        project.publish(Date.today.to_date)
         stub_all_data_compound(project)
 
         get :index, params: {
@@ -45,6 +46,17 @@ RSpec.describe Setup::ProjectRulesController, type: :controller do
         expect(response.body).to include("graph TD")
         expect(response.body).to include("attributed_points--&gt; claimed;")
       end
+      it "should render new documentation for draft" do
+        stub_all_data_compound(project)
+
+        get :index, params: {
+          "project_id" => project.id
+        }
+        expect(response).to have_http_status(200)
+        expect(response.body).to include("graph TD")
+        expect(response.body).to include("attributed_points--&gt; claimed;")
+      end
+
     end
 
 

--- a/spec/models/concerns/paper_trailed_spec.rb
+++ b/spec/models/concerns/paper_trailed_spec.rb
@@ -13,7 +13,6 @@ RSpec.describe PaperTrailed do
   EXCEPTIONS = [
     User,
     ActiveRecord::SchemaMigration,
-    State,
     PaperTrail::Version,
     Version,
     Dhis2Log,

--- a/spec/models/state_spec.rb
+++ b/spec/models/state_spec.rb
@@ -3,7 +3,6 @@
 # Table name: states
 #
 #  id         :integer          not null, primary key
-#  level      :string           default("activity"), not null
 #  name       :string           not null
 #  short_name :string
 #  created_at :datetime         not null

--- a/spec/services/project_factory_spec.rb
+++ b/spec/services/project_factory_spec.rb
@@ -57,7 +57,7 @@ describe ProjectFactory do
     project.save!
 
     new_draft = project.publish(Date.today.to_date)
-    expect(new_draft.changelog.size).to(eq(6))
+    expect(new_draft.changelog.size).to(eq(0))
   end
 
   def count_all_models

--- a/spec/services/project_factory_spec.rb
+++ b/spec/services/project_factory_spec.rb
@@ -64,15 +64,10 @@ describe ProjectFactory do
 
   it "should publish and create a draft with a copy of all the records linked to project with correct project_id" do
     project = full_project
-    project.save!
     project.payment_rules.first.datasets.create!(frequency: "monthly", external_reference: "demodataset")
 
     new_draft = project.publish(Date.today.to_date)
     expect(new_draft.changelog.size).to(eq(0))
-
-    descendants_with_project_id = ActiveRecord::Base.descendants
-                                                    .reject(&:abstract_class?)
-                                                    .reject { |klass| EXCEPTIONS.include?(klass) }
 
     descendants_with_project_id.each do |model|
       counters = count_by_project_id(model.all)

--- a/spec/services/project_factory_spec.rb
+++ b/spec/services/project_factory_spec.rb
@@ -28,7 +28,7 @@ describe ProjectFactory do
     Flipper::Adapters::ActiveRecord::Gate
   ].freeze
 
-  NON_PROJECT_AR =[
+  NON_PROJECT_AR = [
     User,
     Program,
     ProjectAnchor,
@@ -38,7 +38,7 @@ describe ProjectFactory do
     InvoicingJob,
     InvoicingSimulationJob,
     Version
-  ]
+  ].freeze
 
   EXCEPTIONS = INFRA_AR + NON_PROJECT_AR
 
@@ -76,10 +76,16 @@ describe ProjectFactory do
 
     descendants_with_project_id.each do |model|
       counters = count_by_project_id(model.all)
-      #puts model.name + " => " + counters.to_json
+      # puts model.name + " => " + counters.to_json
       expect(counters[project.id]).to eq(counters[new_draft.id])
       expect(counters[project.id]).to be >= 0
     end
+  end
+
+  def descendants_with_project_id
+    ActiveRecord::Base.descendants
+                      .reject(&:abstract_class?)
+                      .reject { |klass| EXCEPTIONS.include?(klass) }
   end
 
   def count_by_project_id(arr)


### PR DESCRIPTION
- remove level column on state
- avoid package.states usage in validations (empty when publishing/cloning)
- avoid package.activities usage in validations (empty when publishing/cloning)
- added papertrail on state
- allow to display documentation on published and draft projects.
- fix deep_clone config to actually clone [everything](https://github.com/moiristo/deep_cloneable#the-dictionary-object-reusage).

TODO
  - add spec for publishing : partially done.

the spec `./spec/services/project_factory_spec.rb` is already better but was not failing on the activity_package as on production project. I don't really found (I think states and activities are not reused) and so might not trigger the same issues but project deep_clone config was clearly not good

This spec on dev branch the PackagePaymentRules were missing  and changelog should have been empty from the begining.
```
Project => {"6":1,"5":1}
Rule => {"5":10,"6":10}
Formula => {"5":27,"6":27}
Package => {"5":4,"6":4}
PackageEntityGroup => {"5":5,"6":5}
PaymentRule => {"5":2,"6":2}
PackagePaymentRule => {"5":16}
FormulaMapping => {"5":3,"6":3}
EntityGroup => {"5":1,"6":1}
State => {"5":9,"6":9}
Activity => {"5":2,"6":2}
ActivityState => {"5":4,"6":4}
ActivityPackage => {"5":8,"6":8}
DecisionTable => {"5":1,"6":1}
PackageState => {"5":12,"6":12}
PaymentRuleDataset => {"5":1,"6":1}
```