### PR TITLE
Fix issues we had during async

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -54,7 +54,6 @@ gem "uglifier", ">= 1.3.0"
 # [webpacker](https://github.com/rails/webpacker)
 gem "webpacker", "~> 4.0.1"
 
-
 ## Authentication
 
 # Flexible authentication solution for Rails with Warden
@@ -63,10 +62,10 @@ gem "devise", "~> 4.6.2"
 
 ## API related
 
+gem "aws-sdk-s3", "~> 1.30.1"
 gem "fast_jsonapi"
 gem "jbuilder", "~> 2.5"
 gem "json", "2.1.0"
-gem "aws-sdk-s3", "~> 1.30.1"
 
 ## Utilities
 
@@ -91,7 +90,6 @@ end
 # Like a modern code version of the mythical beast with 100 serpent hea...
 # [typhoeus](https://github.com/typhoeus/typhoeus)
 gem "typhoeus", "~> 1.3.1"
-
 
 group :development, :test do
   gem "byebug", platform: :mri

--- a/Gemfile
+++ b/Gemfile
@@ -66,6 +66,7 @@ gem "devise", "~> 4.6.2"
 gem "fast_jsonapi"
 gem "jbuilder", "~> 2.5"
 gem "json", "2.1.0"
+gem "aws-sdk-s3", "~> 1.30.1"
 
 ## Utilities
 
@@ -90,6 +91,8 @@ end
 # Like a modern code version of the mythical beast with 100 serpent hea...
 # [typhoeus](https://github.com/typhoeus/typhoeus)
 gem "typhoeus", "~> 1.3.1"
+
+
 group :development, :test do
   gem "byebug", platform: :mri
 
@@ -108,7 +111,6 @@ group :development, :test do
   gem "ruby-prof"
   gem "shoulda-matchers", require: false
 
-  gem "aws-sdk-s3", "~> 1.30.1"
   gem "capybara", "~> 3.12.0"
   gem "json-diff", "~> 0.4.1"
   gem "rubyzip", "~> 1.2.2"

--- a/app/controllers/setup/invoices_controller.rb
+++ b/app/controllers/setup/invoices_controller.rb
@@ -98,6 +98,7 @@ class Setup::InvoicesController < PrivateController
           @not_enqueued_reason = reason
         end
 
+        project.project_anchor.update_token_if_needed
         @simulation_job_url = api_simulation_path(job, token: project.project_anchor.token)
         return render "async_invoice"
       else

--- a/app/controllers/setup/invoices_controller.rb
+++ b/app/controllers/setup/invoices_controller.rb
@@ -91,7 +91,6 @@ class Setup::InvoicesController < PrivateController
         )
         shouldEnqueue, reason = enqueue_simulation_job(job, params[:force])
         if shouldEnqueue
-          job.update(status: "enqueued")
           args = invoicing_request.to_h.merge(simulate_draft: params[:simulate_draft])
           InvoiceSimulationWorker.perform_async(*args.values)
         else
@@ -235,6 +234,8 @@ class Setup::InvoicesController < PrivateController
   end
 
   def enqueue_simulation_job(job, force)
+    # New jobs always need processing
+    return true if job.id_previously_changed?
     return [false, "This job is still processing"] if job.alive?
     if job.processed_within_last?(interval: 10.minutes) && force != "strong"
       [false, "This job was recently processed: #{job.processed_at}, you can force a regeneration with `?force=strong`"]

--- a/app/javascript/packs/components/loader.jsx
+++ b/app/javascript/packs/components/loader.jsx
@@ -44,12 +44,23 @@ class Loader extends React.Component {
   async apiFetch(url) {
     const response = await this.fetchJSON(url);
     if (response.success) {
-      if (!response.payload.data.attributes.isAlive) {
-        clearInterval(this.timer);
-        this.fetchSimulationResult(response.payload.data.attributes.resultUrl);
+      const {
+        isAlive,
+        status,
+        lastError,
+        resultUrl,
+      } = response.payload.data.attributes;
+      if (isAlive) {
+        // I'm still alive, keep polling.
       } else {
-        console.log(response.payload.data);
-        // I'm still alive
+        // I finished processing
+        clearInterval(this.timer);
+        if (status === "processed") {
+          this.fetchSimulationResult(resultUrl);
+        } else {
+          this.showError(lastError);
+        }
+
       }
     } else {
       clearInterval(this.timer);

--- a/app/javascript/packs/components/loader.jsx
+++ b/app/javascript/packs/components/loader.jsx
@@ -58,9 +58,8 @@ class Loader extends React.Component {
         if (status === "processed") {
           this.fetchSimulationResult(resultUrl);
         } else {
-          this.showError(lastError);
+          this.showError({ message: lastError });
         }
-
       }
     } else {
       clearInterval(this.timer);

--- a/app/models/invoicing_job.rb
+++ b/app/models/invoicing_job.rb
@@ -95,6 +95,7 @@ class InvoicingJob < ApplicationRecord
   end
 
   def alive?
+    return false if status.nil?
     return false if status == "processed" || status == "errored"
     return false unless updated_at
     return false if updated_at < 1.day.ago

--- a/app/models/invoicing_job.rb
+++ b/app/models/invoicing_job.rb
@@ -36,11 +36,10 @@ class InvoicingJob < ApplicationRecord
   validates :orgunit_ref, presence: true
 
   enum status: {
-         enqueued: "enqueued",
-         processed: "processed",
-         errored: "errored"
-       }
-
+    enqueued:  "enqueued",
+    processed: "processed",
+    errored:   "errored"
+  }
 
   class LogSubscriber < ActiveSupport::LogSubscriber
     def execute(event)
@@ -77,8 +76,9 @@ class InvoicingJob < ApplicationRecord
 
     def instrument(operation, payload = {}, &block)
       ActiveSupport::Notifications.instrument(
-        "#{operation}.#{self.name.underscore}",
-        payload, &block)
+        "#{operation}.#{name.underscore}",
+        payload, &block
+      )
     end
 
     def time
@@ -105,6 +105,7 @@ class InvoicingJob < ApplicationRecord
     return false if processed? || errored?
     return false unless updated_at
     return false if updated_at < 1.day.ago
+
     true
   end
 
@@ -121,7 +122,7 @@ class InvoicingJob < ApplicationRecord
       self.last_error = nil
       save!
     end
-    self.reload
+    reload
   end
 
   def mark_as_error(start_time, end_time, err)

--- a/app/models/invoicing_simulation_job.rb
+++ b/app/models/invoicing_simulation_job.rb
@@ -10,7 +10,7 @@
 #  orgunit_ref       :string           not null
 #  processed_at      :datetime
 #  sidekiq_job_ref   :string
-#  status            :string
+#  status            :string           default("enqueued")
 #  type              :string           default("InvoicingJob")
 #  user_ref          :string
 #  created_at        :datetime         not null

--- a/app/models/project_anchor.rb
+++ b/app/models/project_anchor.rb
@@ -150,4 +150,15 @@ class ProjectAnchor < ApplicationRecord
   def flipper_id
     "ProjectAnchor:#{id}"
   end
+
+  # If no token is present update the database with a new token.
+  #
+  # Returns the newly set token
+  def update_token_if_needed(force_refresh: false)
+    return if token.present? && !force_refresh
+
+    token = SecureRandom.uuid
+    update(token: token)
+    token
+  end
 end

--- a/app/serializers/invoicing_job_serializer.rb
+++ b/app/serializers/invoicing_job_serializer.rb
@@ -11,7 +11,7 @@
 #  orgunit_ref       :string           not null
 #  processed_at      :datetime
 #  sidekiq_job_ref   :string
-#  status            :string
+#  status            :string           default("enqueued")
 #  type              :string           default("InvoicingJob")
 #  user_ref          :string
 #  created_at        :datetime         not null

--- a/app/workers/invoice_simulation_worker.rb
+++ b/app/workers/invoice_simulation_worker.rb
@@ -66,6 +66,8 @@ class InvoiceSimulationWorker
   end
 
   class Simulation
+    class ErrorDuringSimulation < StandardError; end
+
     attr_accessor :entity, :period, :project_id, :with_details, :engine_version, :simulate_draft
 
     # The class that does all the simulating.
@@ -85,6 +87,10 @@ class InvoiceSimulationWorker
       Invoicing::MapToInvoices.new(invoicing_request, invoicing_entity.fetch_and_solve.solver).call
       json = InvoiceEntityToJson.new(invoicing_entity).call
       json
+    rescue StandardError => e
+      exception = ErrorDuringSimulation.new(e.message)
+      exception.set_backtrace(e.backtrace)
+      raise exception
     end
 
     def invoicing_entity

--- a/app/workers/invoice_simulation_worker.rb
+++ b/app/workers/invoice_simulation_worker.rb
@@ -131,9 +131,5 @@ class InvoiceSimulationWorker
     def project
       @project ||= Project.find(project_id)
     end
-
-    def project_anchor
-      @project.project_anchor
-    end
   end
 end

--- a/config/application.rb
+++ b/config/application.rb
@@ -37,6 +37,8 @@ module Scorpio
       }
     end
 
+    config.active_job.queue_adapter = :sidekiq
+
     # These are defined in `/lib/*.rb
     require "scorpio"
     require "parallel_dhis2"

--- a/db/migrate/20190424081026_change_state_default_to_enqueued.rb
+++ b/db/migrate/20190424081026_change_state_default_to_enqueued.rb
@@ -1,0 +1,8 @@
+class ChangeStateDefaultToEnqueued < ActiveRecord::Migration[5.2]
+  def change
+    # Change the default from nil to 'enqueued'
+    # Backfilling is not needed, I checked and all job's have a status already. This will only
+    # affect new jobs.
+    change_column_default :invoicing_jobs, :status, from: nil, to: InvoicingJob.statuses[:enqueued]
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_03_28_135206) do
+ActiveRecord::Schema.define(version: 2019_04_24_081026) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_stat_statements"
@@ -173,7 +173,7 @@ ActiveRecord::Schema.define(version: 2019_03_28_135206) do
     t.datetime "errored_at"
     t.string "last_error"
     t.integer "duration_ms"
-    t.string "status"
+    t.string "status", default: "enqueued"
     t.string "sidekiq_job_ref"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false

--- a/lib/invoice_entity_to_json.rb
+++ b/lib/invoice_entity_to_json.rb
@@ -119,6 +119,13 @@ class InvoiceEntityToJson
     org_unit.group_ext_ids.include?(project.entity_group.external_reference)
   end
 
+  def non_contracted_orgunit_message(project)
+    "Entity is not in the contracted entity group : #{project.entity_group.name}." \
+     " (Snaphots last updated on #{project.project_anchor.updated_at.to_date})." \
+     " Only simulation will work. Update the group and trigger a dhis2 snaphots." \
+     " Note that it will only fix this issue for current or futur periods."
+  end
+
   def is_input(activity_item, code)
     activity_item.input?(code)
   rescue StandardError

--- a/script/bootstrap
+++ b/script/bootstrap
@@ -49,6 +49,20 @@ which foreman >/dev/null 2>&1 || {
     gem install foreman
 }
 
+# Install bundler if needed
+which yarn >/dev/null 2>&1  || {
+cat <<"YARN"
+You need to install yarn
+
+https://yarnpkg.com/en/docs/install
+
+app/javascripts is used by rails/webpacker, which in turns depends on
+yarn to install the dependencies, so rather than finding out later,
+better install yarn now.
+YARN
+  exit 1
+}
+
 if [ -f "Gemfile" ]; then
     echo "==> Installing gem dependencies…"
     bundle check >/dev/null 2>&1  || {

--- a/spec/controllers/api/invoicing_jobs_controller_spec.rb
+++ b/spec/controllers/api/invoicing_jobs_controller_spec.rb
@@ -42,10 +42,10 @@ RSpec.describe Api::InvoicingJobsController, type: :controller do
                           "erroredAt"     => nil,
                           "durationMs"    => nil,
                           "resultUrl"     => nil,
-                          "status"        => nil,
+                          "status"        => InvoicingJob.statuses[:enqueued],
                           "lastError"     => nil,
                           "sidekiqJobRef" => nil,
-                          "isAlive"       => false }
+                          "isAlive"       => true }
       )
     end
   end

--- a/spec/controllers/api/invoicing_jobs_controller_spec.rb
+++ b/spec/controllers/api/invoicing_jobs_controller_spec.rb
@@ -45,7 +45,7 @@ RSpec.describe Api::InvoicingJobsController, type: :controller do
                           "status"        => nil,
                           "lastError"     => nil,
                           "sidekiqJobRef" => nil,
-                          "isAlive"       => true }
+                          "isAlive"       => false }
       )
     end
   end

--- a/spec/factories/invoicing_jobs.rb
+++ b/spec/factories/invoicing_jobs.rb
@@ -10,7 +10,7 @@
 #  orgunit_ref       :string           not null
 #  processed_at      :datetime
 #  sidekiq_job_ref   :string
-#  status            :string
+#  status            :string           default("enqueued")
 #  type              :string           default("InvoicingJob")
 #  user_ref          :string
 #  created_at        :datetime         not null
@@ -33,6 +33,7 @@ FactoryBot.define do
     duration_ms { 6.seconds * 1000 }
     orgunit_ref { "aaa_123" }
     type { "InvoicingJob" }
+    project_anchor
   end
 
   factory :invoicing_simulation_job, parent: :invoicing_job do
@@ -41,14 +42,14 @@ FactoryBot.define do
 
   trait :processed do
     processed_at { 10.minutes.ago }
-    status { "processed" }
+    status { InvoicingJob.statuses[:processed] }
   end
 
   trait :errored do
     processed_at { nil }
     errored_at { 10.minutes.ago }
     last_error { "This was the error" }
-    status { "errored" }
+    status { InvoicingJob.statuses[:errored] }
   end
 
   trait :with_result do

--- a/spec/factories/project_anchors.rb
+++ b/spec/factories/project_anchors.rb
@@ -19,5 +19,6 @@
 
 FactoryBot.define do
   factory :project_anchor do
+    program
   end
 end

--- a/spec/models/invoicing_job_spec.rb
+++ b/spec/models/invoicing_job_spec.rb
@@ -11,7 +11,7 @@
 #  orgunit_ref       :string           not null
 #  processed_at      :datetime
 #  sidekiq_job_ref   :string
-#  status            :string
+#  status            :string           default("enqueued")
 #  type              :string           default("InvoicingJob")
 #  user_ref          :string
 #  created_at        :datetime         not null
@@ -60,9 +60,9 @@ RSpec.describe InvoicingJob, type: :model do
       expect(job.alive?).to eq true
     end
 
-    it "new job is not immediately alive" do
+    it "new job is immediately alive" do
       job = project_anchor.invoicing_jobs.create!(dhis2_period: "2016Q4", orgunit_ref: "orgunit_ref")
-      expect(job.alive?).to eq false
+      expect(job.alive?).to eq true
     end
   end
 
@@ -152,6 +152,30 @@ RSpec.describe InvoicingJob, type: :model do
       job = FactoryBot.build_stubbed(:invoicing_simulation_job, :errored)
       job.processed_at = 11.minutes.ago
       expect(job.processed_within_last?(interval: 10.minutes)).to eq false
+    end
+  end
+
+  describe "status" do
+    it 'adds scopes' do
+      processed_job = FactoryBot.create(:invoicing_simulation_job, :processed)
+      errored_job = FactoryBot.create(:invoicing_simulation_job, :errored)
+      new_job = FactoryBot.create(:invoicing_simulation_job)
+      expect(InvoicingJob.processed.pluck(:id)).to eq([processed_job.id])
+      expect(InvoicingJob.errored.pluck(:id)).to eq([errored_job.id])
+      expect(InvoicingJob.enqueued.pluck(:id)).to eq([new_job.id])
+    end
+
+    it 'complains on invalid state' do
+      new_job = FactoryBot.create(:invoicing_simulation_job)
+
+      expect {
+        new_job.status = "amazing-but-faulty"
+      }.to raise_error(ArgumentError)
+    end
+
+    it 'defaults to enqueued' do
+      new_job = FactoryBot.create(:invoicing_simulation_job)
+      expect(new_job.enqueued?).to eq(true)
     end
   end
 end

--- a/spec/models/invoicing_job_spec.rb
+++ b/spec/models/invoicing_job_spec.rb
@@ -59,6 +59,11 @@ RSpec.describe InvoicingJob, type: :model do
       job = project_anchor.invoicing_jobs.create!(dhis2_period: "2016Q4", orgunit_ref: "orgunit_ref", status: "enqueued")
       expect(job.alive?).to eq true
     end
+
+    it "new job is not immediately alive" do
+      job = project_anchor.invoicing_jobs.create!(dhis2_period: "2016Q4", orgunit_ref: "orgunit_ref")
+      expect(job.alive?).to eq false
+    end
   end
 
   it "handle nicely when no invoicing job" do

--- a/spec/models/project_anchor_spec.rb
+++ b/spec/models/project_anchor_spec.rb
@@ -1,5 +1,25 @@
 # frozen_string_literal: true
 
+# == Schema Information
+#
+# Table name: project_anchors
+#
+#  id         :bigint(8)        not null, primary key
+#  token      :string
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#  program_id :integer          not null
+#
+# Indexes
+#
+#  index_project_anchors_on_program_id  (program_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (program_id => programs.id)
+#
+
+
 require "rails_helper"
 
 RSpec.describe ProjectAnchor, type: :model do

--- a/spec/models/project_anchor_spec.rb
+++ b/spec/models/project_anchor_spec.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe ProjectAnchor, type: :model do
+  describe "#update_token_if_needed" do
+    it "does not update if token already set" do
+      anchor = ProjectAnchor.new(token: "abc123")
+      anchor.update_token_if_needed
+      expect(anchor.token).to eq("abc123")
+    end
+
+    it "updates if no token set" do
+      anchor = ProjectAnchor.new
+      anchor.update_token_if_needed
+      expect(anchor.token).to_not be_nil
+    end
+
+    it "can force_refresh" do
+      anchor = ProjectAnchor.new(token: "abc123")
+      anchor.update_token_if_needed(force_refresh: true)
+      expect(anchor.token).to_not eq("abc123")
+      expect(anchor.token).to_not be_nil
+    end
+
+    it "returns the token" do
+      anchor = ProjectAnchor.new
+      new_token = anchor.update_token_if_needed
+      expect(anchor.token).to eq(new_token)
+    end
+  end
+end

--- a/spec/workers/invoice_for_project_anchor_worker_spec.rb
+++ b/spec/workers/invoice_for_project_anchor_worker_spec.rb
@@ -1,14 +1,12 @@
 # frozen_string_literal: true
 
 require "rails_helper"
-require_relative "./dhis2_snapshot_fixture"
 
+require_relative "./project_fixture"
 RSpec.describe InvoiceForProjectAnchorWorker do
-  include Dhis2SnapshotFixture
-  include_context "basic_context"
-
+  include ProjectFixture
   ORG_UNIT_ID = "vRC0stJ5y9Q"
-
+  include_context "basic_context"
   let(:program) { create :program }
 
   let!(:project) do
@@ -23,117 +21,14 @@ RSpec.describe InvoiceForProjectAnchorWorker do
     project.entity_group.save!
     project
   end
-
   let(:worker) { described_class.new }
 
-  def with_last_year_verified_values(project)
-    project.packages.first.activity_rule.formulas.create(
-      code:        "verified_last_year_average",
-      expression:  "avg(%{verified_previous_year_values})",
-      description: "last year verified payment"
-    )
-    self
-  end
-
-  def with_cycle_values(project)
-    project.packages.first.activity_rule.formulas.create(
-      code:        "verified_current_cycle_average",
-      expression:  "avg(%{verified_current_cycle_values})",
-      description: "current cycle verified payment"
-    )
-    self
-  end
-
-  def with_monthly_payment_rule(project)
-    payment_rule = project.payment_rules.create!(
-      packages:        [project.packages[0], project.packages[2]],
-      frequency:       "monthly",
-      rule_attributes: {
-        name:                "monthly payments",
-        kind:                "payment",
-        formulas_attributes: [
-          {
-            code:        "payment",
-            expression:  "quantity_total_pma + quality_technical_score_value * (sum(quantity_total_pma, %{quantity_total_pma_values})) ",
-            description: "doc monthly payment"
-          }
-        ]
-      }
-    )
-
-    Rails.logger.info "added payment for  #{payment_rule.packages.map(&:name)}"
-
-    self
-  end
-
-  def with_multi_entity_rule(project)
-    package = project.packages.first
-
-    package.update!(ogs_reference: "J5jldMd8OHv", kind: "multi-groupset")
-    package.package_states.each_with_index do |package_state, index|
-      package_state.update!(ds_external_reference: "ds-#{index}")
-    end
-    rule = package.rules.create!(name: "multi-entities test", kind: "multi-entities")
-    rule.decision_tables.create!(
-      content: fixture_content(:scorpio, "decision_table_multi_entities.csv")
-    )
-
-    package.activity_rule.formulas.create!(
-      code:        "org_units_count_exported",
-      description: "org_units_count_exported",
-      expression:  "org_units_count"
-    )
-
-    package.activity_rule.formulas.create!(
-      code:        "org_units_sum_if_count_exported",
-      description: "org_units_sum_if_count_exported",
-      expression:  "org_units_sum_if_count"
-    )
-  end
-
-  def generate_quarterly_values_for(project)
-    refs = project.activities
-                  .flat_map(&:activity_states)
-                  .map(&:external_reference)
-                  .uniq
-                  .reject(&:empty?).sort
-    values = refs.each_with_index.map do |data_element, index|
-      [(1..4).map do |quarter|
-        {
-          dataElement:          data_element,
-          value:                100 + (index % 2),
-          period:               "2015Q#{quarter}",
-          orgUnit:              ORG_UNIT_ID,
-          categoryOptionCombo:  "HllvX50cXC0",
-          attributeOptionCombo: "HllvX50cXC0"
-        }
-      end]
-    end
-
-    values.flatten
-  end
-
-  def create_snaphots(project)
-    return if project.project_anchor.dhis2_snapshots.any?
-    stub_organisation_unit_group_sets(project)
-    stub_organisation_unit_groups(project)
-
-    stub_organisation_units(project)
-    stub_data_elements(project)
-    stub_data_elements_groups(project)
-    stub_system_info(project)
-    stub_indicators(project)
-
-    Dhis2SnapshotWorker.new.perform(project.project_anchor.id)
-    WebMock.reset!
-  end
-
   describe "throttled" do
-    it 'defaults to 3 concurrent' do
+    it "defaults to 3 concurrent" do
       expect(Sidekiq::Throttled::Registry.get(InvoiceForProjectAnchorWorker).concurrency.limit).to eq(3)
     end
 
-    it 'can be overridden with env' do
+    it "can be overridden with env" do
       skip("The `load` resets the code coverage, this test will pass but code coverage is incorrect")
       current_env = ENV["SDKQ_MAX_CONCURRENT_INVOICE"]
       ENV["SDKQ_MAX_CONCURRENT_INVOICE"] = "10"
@@ -472,16 +367,6 @@ RSpec.describe InvoiceForProjectAnchorWorker do
 
       expect(export_request).to have_been_made.once
     end
-  end
-
-  def with_latest_engine(project)
-    project.update!(engine_version: 3)
-    project
-  end
-
-  def with_new_engine(project)
-    project.update!(engine_version: 2)
-    project
   end
 
   def stub_dhis2_values_yearly(values, start_date)

--- a/spec/workers/invoice_simulation_worker_spec.rb
+++ b/spec/workers/invoice_simulation_worker_spec.rb
@@ -1,0 +1,132 @@
+# frozen_string_literal: true
+
+require "fileutils"
+
+require "rails_helper"
+
+require_relative "./project_fixture"
+
+RSpec.describe InvoiceSimulationWorker do
+  include ProjectFixture
+  ORG_UNIT_ID = "vRC0stJ5y9Q"
+  include_context "basic_context"
+
+  let(:program) { create :program }
+
+  let!(:project) do
+    project = full_project
+    project.save!
+    user.save!
+    user.program = program
+    project.payment_rules.each { |p| p.update(frequency: "quarterly") }
+    project.packages.each { |p| p.update(frequency: "quarterly") }
+
+    with_activities_and_formula_mappings(project)
+    create_snaphots(project)
+    with_latest_engine(project)
+    project.entity_group.external_reference = "MAs88nJc9nL"
+    project.entity_group.save!
+    project
+  end
+  let(:worker) { described_class.new }
+
+  it "works for non contracted but shows a warning" do
+    project.entity_group.external_reference = "external_reference"
+    project.entity_group.save!
+    stub_request(:get, "http://play.dhis2.org/demo/api/dataValueSets?children=false&orgUnit=#{ORG_UNIT_ID}&period=2015Q1")
+      .to_return(status: 200, body: JSON.pretty_generate("dataValues": generate_quarterly_values_for(project)))
+
+    simulation_json = with_mocked_s3 do
+      worker.perform(ORG_UNIT_ID, "2015Q1", project.id, true, 3, true)
+    end
+
+    expect(simulation_json["request"]["warnings"]).to eq(
+      "Entity is not in the contracted entity group : Clinic. "\
+      "(Snaphots last updated on 2019-04-29). Only simulation will work. "\
+      "Update the group and trigger a dhis2 snaphots. "\
+      "Note that it will only fix this issue for current or futur periods."
+    )
+  end
+
+  it "stores exception message when dhis2 is not available" do
+    stub_request(:get, "http://play.dhis2.org/demo/api/dataValueSets?children=false&orgUnit=#{ORG_UNIT_ID}&period=2015Q1")
+      .to_return(status: 503, body: "")
+
+    with_mocked_s3 do
+      begin
+        worker.perform(ORG_UNIT_ID, "2015Q1", project.id, true, 3, true)
+      rescue InvoiceSimulationWorker::Simulation::ErrorDuringSimulation => _ignored
+      end
+    end
+
+    expect(InvoicingSimulationJob.last.last_error).to eq("InvoiceSimulationWorker::Simulation::ErrorDuringSimulation: 503 Service Unavailable")
+  end
+
+  it "stores exception message when there's problem with formula evaluation" do
+    project.packages.first.activity_rule.formula("amount").update(expression: "tarif / 0")
+
+    stub_request(:get, "http://play.dhis2.org/demo/api/dataValueSets?children=false&orgUnit=#{ORG_UNIT_ID}&period=2015Q1")
+      .to_return(status: 200, body: JSON.pretty_generate("dataValues": generate_quarterly_values_for(project)))
+
+    with_mocked_s3 do
+      begin
+        worker.perform(ORG_UNIT_ID, "2015Q1", project.id, false, 3, true)
+      rescue InvoiceSimulationWorker::Simulation::ErrorDuringSimulation => _ignored
+      end
+    end
+
+    expect(InvoicingSimulationJob.last.last_error).to eq("InvoiceSimulationWorker::Simulation::ErrorDuringSimulation: "\
+      "In equation quantity_pma_clients_sous_traitement_arv_suivi_pendant_les_6_premiers_mois_amount_for_vRC0stJ5y9Q_and_2015q1 "\
+      "Divide by zero quantity_pma_clients_sous_traitement_arv_suivi_pendant_les_6_premiers_mois_amount_for_vRC0stJ5y9Q_and_2015q1 "\
+      ":= quantity_pma_clients_sous_traitement_arv_suivi_pendant_les_6_premiers_mois_tarif_for_vRC0stJ5y9Q_and_2015q1 / 0")
+  end
+
+  # double to mock s3 related calls
+  let(:active_storage_client) { double("active_storage_client") }
+  let(:s3_bucket) { double("simulation_bucket") }
+  let(:s3_bucket_client) { double("s3_bucket_client") }
+
+  # mock some specific s3 and return the simulation job json if simulation is successful
+  def with_mocked_s3
+    # as we couldn't use the default s3 active storage to store gzipped json
+    # the production code is assuming some s3 dependencies (service and bucket)
+    # that are not provided by the non-s3 ActiveStorage::Service::DiskService
+    # so we mock them
+    asc = active_storage_client
+    bucket = s3_bucket
+    ActiveStorage::Blob.service.define_singleton_method(:client) { asc }
+    ActiveStorage::Blob.service.define_singleton_method(:bucket) { bucket }
+
+    # expect object lookup by blob key
+    # and at the sametime store the expected path by ActiveStorage::Service::DiskService
+    # for the "put"
+    file_path = nil
+    allow(bucket).to receive(:object) { |spy_blob_key|
+      path = ActiveStorage::Blob.service.send(:path_for, spy_blob_key)
+      file_path = path
+      s3_bucket_client
+    }
+
+    # store the file in binary mode (gzip json)
+    allow(s3_bucket_client).to receive(:put) { |args|
+      dirname = File.dirname(file_path)
+      puts "****************** \n"+dirname+"****************** "
+      FileUtils.mkdir_p(dirname) unless File.directory?(dirname)
+      File.open(file_path, "w") { |file|
+        file.binmode
+        file.write(args[:body].read)
+      }
+    }
+
+    # yield the block to trigger the simulation with desired options
+    # allow also rescuing some expected exception
+    yield
+
+    # load, unzip and parse the file (if one was generated)
+    if file_path
+      data = Zlib::GzipReader.open(file_path, &:read)
+      File.delete(file_path)
+      JSON.parse(data)
+    end
+  end
+end

--- a/spec/workers/project_fixture.rb
+++ b/spec/workers/project_fixture.rb
@@ -1,0 +1,121 @@
+# frozen_string_literal: true
+
+require_relative "./dhis2_snapshot_fixture"
+module ProjectFixture
+  include Dhis2SnapshotFixture
+
+  ORG_UNIT_ID = "vRC0stJ5y9Q"
+
+  def with_latest_engine(project)
+    project.update!(engine_version: 3)
+    project
+  end
+
+  def with_new_engine(project)
+    project.update!(engine_version: 2)
+    project
+  end
+
+  def with_last_year_verified_values(project)
+    project.packages.first.activity_rule.formulas.create(
+      code:        "verified_last_year_average",
+      expression:  "avg(%{verified_previous_year_values})",
+      description: "last year verified payment"
+    )
+    self
+  end
+
+  def with_cycle_values(project)
+    project.packages.first.activity_rule.formulas.create(
+      code:        "verified_current_cycle_average",
+      expression:  "avg(%{verified_current_cycle_values})",
+      description: "current cycle verified payment"
+    )
+    self
+  end
+
+  def with_monthly_payment_rule(project)
+    payment_rule = project.payment_rules.create!(
+      packages:        [project.packages[0], project.packages[2]],
+      frequency:       "monthly",
+      rule_attributes: {
+        name:                "monthly payments",
+        kind:                "payment",
+        formulas_attributes: [
+          {
+            code:        "payment",
+            expression:  "quantity_total_pma + quality_technical_score_value * (sum(quantity_total_pma, %{quantity_total_pma_values})) ",
+            description: "doc monthly payment"
+          }
+        ]
+      }
+    )
+
+    Rails.logger.info "added payment for  #{payment_rule.packages.map(&:name)}"
+
+    self
+  end
+
+  def with_multi_entity_rule(project)
+    package = project.packages.first
+
+    package.update!(ogs_reference: "J5jldMd8OHv", kind: "multi-groupset")
+    package.package_states.each_with_index do |package_state, index|
+      package_state.update!(ds_external_reference: "ds-#{index}")
+    end
+    rule = package.rules.create!(name: "multi-entities test", kind: "multi-entities")
+    rule.decision_tables.create!(
+      content: fixture_content(:scorpio, "decision_table_multi_entities.csv")
+    )
+
+    package.activity_rule.formulas.create!(
+      code:        "org_units_count_exported",
+      description: "org_units_count_exported",
+      expression:  "org_units_count"
+    )
+
+    package.activity_rule.formulas.create!(
+      code:        "org_units_sum_if_count_exported",
+      description: "org_units_sum_if_count_exported",
+      expression:  "org_units_sum_if_count"
+    )
+  end
+
+  def generate_quarterly_values_for(project)
+    refs = project.activities
+                  .flat_map(&:activity_states)
+                  .map(&:external_reference)
+                  .uniq
+                  .reject(&:empty?).sort
+    values = refs.each_with_index.map do |data_element, index|
+      [(1..4).map do |quarter|
+        {
+          dataElement:          data_element,
+          value:                (100 + (index % 2)).to_s,
+          period:               "2015Q#{quarter}",
+          orgUnit:              ORG_UNIT_ID,
+          categoryOptionCombo:  "HllvX50cXC0",
+          attributeOptionCombo: "HllvX50cXC0"
+        }
+      end]
+    end
+
+    values.flatten
+  end
+
+  def create_snaphots(project)
+    return if project.project_anchor.dhis2_snapshots.any?
+
+    stub_organisation_unit_group_sets(project)
+    stub_organisation_unit_groups(project)
+
+    stub_organisation_units(project)
+    stub_data_elements(project)
+    stub_data_elements_groups(project)
+    stub_system_info(project)
+    stub_indicators(project)
+
+    Dhis2SnapshotWorker.new.perform(project.project_anchor.id)
+    WebMock.reset!
+  end
+end


### PR DESCRIPTION
I deployed the async version on staging and during testing of that I ran into these issues:

- Projects sometimes didn't have a token set
- Jobs without a state were considered 'alive' (which was wrong)
- Error handling was not that great (now showing actual errors)
- Errors during simulation now bubble up to the user
- ActiveJob used its own async instead of sidekiq
- Cleaned up bootstrap script to include yarn
