### PR TITLE
Add spec for simulation worker

### DIFF
--- a/app/workers/invoice_simulation_worker.rb
+++ b/app/workers/invoice_simulation_worker.rb
@@ -131,9 +131,5 @@ class InvoiceSimulationWorker
     def project
       @project ||= Project.find(project_id)
     end
-
-    def project_anchor
-      @project.project_anchor
-    end
   end
 end

--- a/spec/workers/invoice_for_project_anchor_worker_spec.rb
+++ b/spec/workers/invoice_for_project_anchor_worker_spec.rb
@@ -1,14 +1,12 @@
 # frozen_string_literal: true
 
 require "rails_helper"
-require_relative "./dhis2_snapshot_fixture"
 
+require_relative "./project_fixture"
 RSpec.describe InvoiceForProjectAnchorWorker do
-  include Dhis2SnapshotFixture
-  include_context "basic_context"
-
+  include ProjectFixture
   ORG_UNIT_ID = "vRC0stJ5y9Q"
-
+  include_context "basic_context"
   let(:program) { create :program }
 
   let!(:project) do
@@ -23,117 +21,14 @@ RSpec.describe InvoiceForProjectAnchorWorker do
     project.entity_group.save!
     project
   end
-
   let(:worker) { described_class.new }
 
-  def with_last_year_verified_values(project)
-    project.packages.first.activity_rule.formulas.create(
-      code:        "verified_last_year_average",
-      expression:  "avg(%{verified_previous_year_values})",
-      description: "last year verified payment"
-    )
-    self
-  end
-
-  def with_cycle_values(project)
-    project.packages.first.activity_rule.formulas.create(
-      code:        "verified_current_cycle_average",
-      expression:  "avg(%{verified_current_cycle_values})",
-      description: "current cycle verified payment"
-    )
-    self
-  end
-
-  def with_monthly_payment_rule(project)
-    payment_rule = project.payment_rules.create!(
-      packages:        [project.packages[0], project.packages[2]],
-      frequency:       "monthly",
-      rule_attributes: {
-        name:                "monthly payments",
-        kind:                "payment",
-        formulas_attributes: [
-          {
-            code:        "payment",
-            expression:  "quantity_total_pma + quality_technical_score_value * (sum(quantity_total_pma, %{quantity_total_pma_values})) ",
-            description: "doc monthly payment"
-          }
-        ]
-      }
-    )
-
-    Rails.logger.info "added payment for  #{payment_rule.packages.map(&:name)}"
-
-    self
-  end
-
-  def with_multi_entity_rule(project)
-    package = project.packages.first
-
-    package.update!(ogs_reference: "J5jldMd8OHv", kind: "multi-groupset")
-    package.package_states.each_with_index do |package_state, index|
-      package_state.update!(ds_external_reference: "ds-#{index}")
-    end
-    rule = package.rules.create!(name: "multi-entities test", kind: "multi-entities")
-    rule.decision_tables.create!(
-      content: fixture_content(:scorpio, "decision_table_multi_entities.csv")
-    )
-
-    package.activity_rule.formulas.create!(
-      code:        "org_units_count_exported",
-      description: "org_units_count_exported",
-      expression:  "org_units_count"
-    )
-
-    package.activity_rule.formulas.create!(
-      code:        "org_units_sum_if_count_exported",
-      description: "org_units_sum_if_count_exported",
-      expression:  "org_units_sum_if_count"
-    )
-  end
-
-  def generate_quarterly_values_for(project)
-    refs = project.activities
-                  .flat_map(&:activity_states)
-                  .map(&:external_reference)
-                  .uniq
-                  .reject(&:empty?).sort
-    values = refs.each_with_index.map do |data_element, index|
-      [(1..4).map do |quarter|
-        {
-          dataElement:          data_element,
-          value:                100 + (index % 2),
-          period:               "2015Q#{quarter}",
-          orgUnit:              ORG_UNIT_ID,
-          categoryOptionCombo:  "HllvX50cXC0",
-          attributeOptionCombo: "HllvX50cXC0"
-        }
-      end]
-    end
-
-    values.flatten
-  end
-
-  def create_snaphots(project)
-    return if project.project_anchor.dhis2_snapshots.any?
-    stub_organisation_unit_group_sets(project)
-    stub_organisation_unit_groups(project)
-
-    stub_organisation_units(project)
-    stub_data_elements(project)
-    stub_data_elements_groups(project)
-    stub_system_info(project)
-    stub_indicators(project)
-
-    Dhis2SnapshotWorker.new.perform(project.project_anchor.id)
-    WebMock.reset!
-  end
-
   describe "throttled" do
-    it 'defaults to 3 concurrent' do
+    it "defaults to 3 concurrent" do
       expect(Sidekiq::Throttled::Registry.get(InvoiceForProjectAnchorWorker).concurrency.limit).to eq(3)
     end
 
-    it 'can be overridden with env' do
+    it "can be overridden with env" do
       skip("The `load` resets the code coverage, this test will pass but code coverage is incorrect")
       current_env = ENV["SDKQ_MAX_CONCURRENT_INVOICE"]
       ENV["SDKQ_MAX_CONCURRENT_INVOICE"] = "10"
@@ -472,16 +367,6 @@ RSpec.describe InvoiceForProjectAnchorWorker do
 
       expect(export_request).to have_been_made.once
     end
-  end
-
-  def with_latest_engine(project)
-    project.update!(engine_version: 3)
-    project
-  end
-
-  def with_new_engine(project)
-    project.update!(engine_version: 2)
-    project
   end
 
   def stub_dhis2_values_yearly(values, start_date)

--- a/spec/workers/invoice_simulation_worker_spec.rb
+++ b/spec/workers/invoice_simulation_worker_spec.rb
@@ -10,6 +10,7 @@ RSpec.describe InvoiceSimulationWorker do
   include ProjectFixture
   ORG_UNIT_ID = "vRC0stJ5y9Q"
   include_context "basic_context"
+
   let(:program) { create :program }
 
   let!(:project) do
@@ -29,11 +30,7 @@ RSpec.describe InvoiceSimulationWorker do
   end
   let(:worker) { described_class.new }
 
-  let(:active_storage_client) { double("active_storage_client") }
-  let(:s3_bucket) { double("simulation_bucket") }
-  let(:s3_bucket_client) { double("s3_bucket_client") }
-
-  it "works for non contracted" do
+  it "works for non contracted but shows a warning" do
     project.entity_group.external_reference = "external_reference"
     project.entity_group.save!
     stub_request(:get, "http://play.dhis2.org/demo/api/dataValueSets?children=false&orgUnit=#{ORG_UNIT_ID}&period=2015Q1")
@@ -43,7 +40,12 @@ RSpec.describe InvoiceSimulationWorker do
       worker.perform(ORG_UNIT_ID, "2015Q1", project.id, true, 3, true)
     end
 
-    expect(simulation_json["request"]["warnings"]).to eq("Entity is not in the contracted entity group : Clinic. (Snaphots last updated on 2019-04-29). Only simulation will work. Update the group and trigger a dhis2 snaphots. Note that it will only fix this issue for current or futur periods.")
+    expect(simulation_json["request"]["warnings"]).to eq(
+      "Entity is not in the contracted entity group : Clinic. "\
+      "(Snaphots last updated on 2019-04-29). Only simulation will work. "\
+      "Update the group and trigger a dhis2 snaphots. "\
+      "Note that it will only fix this issue for current or futur periods."
+    )
   end
 
   it "stores exception message when dhis2 is not available" do
@@ -53,37 +55,76 @@ RSpec.describe InvoiceSimulationWorker do
     with_mocked_s3 do
       begin
         worker.perform(ORG_UNIT_ID, "2015Q1", project.id, true, 3, true)
-      rescue InvoiceSimulationWorker::Simulation::ErrorDuringSimulation => ignored
+      rescue InvoiceSimulationWorker::Simulation::ErrorDuringSimulation => _ignored
       end
     end
 
     expect(InvoicingSimulationJob.last.last_error).to eq("InvoiceSimulationWorker::Simulation::ErrorDuringSimulation: 503 Service Unavailable")
   end
 
+  it "stores exception message when there's problem with formula evaluation" do
+    project.packages.first.activity_rule.formula("amount").update(expression: "tarif / 0")
+
+    stub_request(:get, "http://play.dhis2.org/demo/api/dataValueSets?children=false&orgUnit=#{ORG_UNIT_ID}&period=2015Q1")
+      .to_return(status: 200, body: JSON.pretty_generate("dataValues": generate_quarterly_values_for(project)))
+
+    with_mocked_s3 do
+      begin
+        worker.perform(ORG_UNIT_ID, "2015Q1", project.id, false, 3, true)
+      rescue InvoiceSimulationWorker::Simulation::ErrorDuringSimulation => _ignored
+      end
+    end
+
+    expect(InvoicingSimulationJob.last.last_error).to eq("InvoiceSimulationWorker::Simulation::ErrorDuringSimulation: "\
+      "In equation quantity_pma_clients_sous_traitement_arv_suivi_pendant_les_6_premiers_mois_amount_for_vRC0stJ5y9Q_and_2015q1 "\
+      "Divide by zero quantity_pma_clients_sous_traitement_arv_suivi_pendant_les_6_premiers_mois_amount_for_vRC0stJ5y9Q_and_2015q1 "\
+      ":= quantity_pma_clients_sous_traitement_arv_suivi_pendant_les_6_premiers_mois_tarif_for_vRC0stJ5y9Q_and_2015q1 / 0")
+  end
+
+  # double to mock s3 related calls
+  let(:active_storage_client) { double("active_storage_client") }
+  let(:s3_bucket) { double("simulation_bucket") }
+  let(:s3_bucket_client) { double("s3_bucket_client") }
+
+  # mock some specific s3 and return the simulation job json if simulation is successful
   def with_mocked_s3
+    # as we couldn't use the default s3 active storage to store gzipped json
+    # the production code is assuming some s3 dependencies (service and bucket)
+    # that are not provided by the non-s3 ActiveStorage::Service::DiskService
+    # so we mock them
     asc = active_storage_client
     bucket = s3_bucket
     ActiveStorage::Blob.service.define_singleton_method(:client) { asc }
     ActiveStorage::Blob.service.define_singleton_method(:bucket) { bucket }
 
+    # expect object lookup by blob key
+    # and at the sametime store the expected path by ActiveStorage::Service::DiskService
+    # for the "put"
     file_path = nil
     allow(bucket).to receive(:object) { |spy_blob_key|
       path = ActiveStorage::Blob.service.send(:path_for, spy_blob_key)
       file_path = path
       s3_bucket_client
     }
+
+    # store the file in binary mode (gzip json)
     allow(s3_bucket_client).to receive(:put) { |args|
       dirname = File.dirname(file_path)
+      puts "****************** \n"+dirname+"****************** "
       FileUtils.mkdir_p(dirname) unless File.directory?(dirname)
       File.open(file_path, "w") { |file|
         file.binmode
         file.write(args[:body].read)
       }
     }
+
+    # yield the block to trigger the simulation with desired options
+    # allow also rescuing some expected exception
     yield
+
+    # load, unzip and parse the file (if one was generated)
     if file_path
       data = Zlib::GzipReader.open(file_path, &:read)
-
       File.delete(file_path)
       JSON.parse(data)
     end

--- a/spec/workers/invoice_simulation_worker_spec.rb
+++ b/spec/workers/invoice_simulation_worker_spec.rb
@@ -1,0 +1,75 @@
+# frozen_string_literal: true
+
+require "fileutils"
+
+require "rails_helper"
+
+require_relative "./project_fixture"
+
+RSpec.describe InvoiceSimulationWorker do
+  include ProjectFixture
+  ORG_UNIT_ID = "vRC0stJ5y9Q"
+  include_context "basic_context"
+  let(:program) { create :program }
+
+  let!(:project) do
+    project = full_project
+    project.save!
+    user.save!
+    user.program = program
+    project.payment_rules.each { |p| p.update(frequency: "quarterly") }
+    project.packages.each { |p| p.update(frequency: "quarterly") }
+
+    with_activities_and_formula_mappings(project)
+    create_snaphots(project)
+    with_latest_engine(project)
+    project.entity_group.external_reference = "MAs88nJc9nL"
+    project.entity_group.save!
+    project
+  end
+  let(:worker) { described_class.new }
+
+  let(:active_storage_client) { double("active_storage_client") }
+  let(:s3_bucket) { double("simulation_bucket") }
+  let(:s3_bucket_client) { double("s3_bucket_client") }
+
+  it "works for non contracted" do
+    project.entity_group.external_reference = "external_reference"
+    project.entity_group.save!
+    stub_request(:get, "http://play.dhis2.org/demo/api/dataValueSets?children=false&orgUnit=#{ORG_UNIT_ID}&period=2015Q1")
+      .to_return(status: 200, body: JSON.pretty_generate("dataValues": generate_quarterly_values_for(project)))
+
+    simulation_json = with_mocked_s3 do
+      worker.perform(ORG_UNIT_ID, "2015Q1", project.id, true, 3, true)
+    end
+
+    expect(simulation_json["request"]["warnings"]).to eq("Entity is not in the contracted entity group : Clinic. (Snaphots last updated on 2019-04-29). Only simulation will work. Update the group and trigger a dhis2 snaphots. Note that it will only fix this issue for current or futur periods.")
+  end
+
+  def with_mocked_s3
+    asc = active_storage_client
+    bucket = s3_bucket
+    ActiveStorage::Blob.service.define_singleton_method(:client) { asc }
+    ActiveStorage::Blob.service.define_singleton_method(:bucket) { bucket }
+
+    file_path = nil
+    allow(bucket).to receive(:object) { |spy_blob_key|
+      path = ActiveStorage::Blob.service.send(:path_for, spy_blob_key)
+      file_path = path
+      s3_bucket_client
+    }
+    allow(s3_bucket_client).to receive(:put) { |args|
+      dirname = File.dirname(file_path)
+      FileUtils.mkdir_p(dirname) unless File.directory?(dirname)
+      File.open(file_path, "w") { |file|
+        file.binmode
+        file.write(args[:body].read)
+      }
+    }
+    yield
+    data = Zlib::GzipReader.open(file_path, &:read)
+
+    File.delete(file_path)
+    JSON.parse(data)
+  end
+end

--- a/spec/workers/project_fixture.rb
+++ b/spec/workers/project_fixture.rb
@@ -1,0 +1,121 @@
+# frozen_string_literal: true
+
+require_relative "./dhis2_snapshot_fixture"
+module ProjectFixture
+  include Dhis2SnapshotFixture
+
+  ORG_UNIT_ID = "vRC0stJ5y9Q"
+
+  def with_latest_engine(project)
+    project.update!(engine_version: 3)
+    project
+  end
+
+  def with_new_engine(project)
+    project.update!(engine_version: 2)
+    project
+  end
+
+  def with_last_year_verified_values(project)
+    project.packages.first.activity_rule.formulas.create(
+      code:        "verified_last_year_average",
+      expression:  "avg(%{verified_previous_year_values})",
+      description: "last year verified payment"
+    )
+    self
+  end
+
+  def with_cycle_values(project)
+    project.packages.first.activity_rule.formulas.create(
+      code:        "verified_current_cycle_average",
+      expression:  "avg(%{verified_current_cycle_values})",
+      description: "current cycle verified payment"
+    )
+    self
+  end
+
+  def with_monthly_payment_rule(project)
+    payment_rule = project.payment_rules.create!(
+      packages:        [project.packages[0], project.packages[2]],
+      frequency:       "monthly",
+      rule_attributes: {
+        name:                "monthly payments",
+        kind:                "payment",
+        formulas_attributes: [
+          {
+            code:        "payment",
+            expression:  "quantity_total_pma + quality_technical_score_value * (sum(quantity_total_pma, %{quantity_total_pma_values})) ",
+            description: "doc monthly payment"
+          }
+        ]
+      }
+    )
+
+    Rails.logger.info "added payment for  #{payment_rule.packages.map(&:name)}"
+
+    self
+  end
+
+  def with_multi_entity_rule(project)
+    package = project.packages.first
+
+    package.update!(ogs_reference: "J5jldMd8OHv", kind: "multi-groupset")
+    package.package_states.each_with_index do |package_state, index|
+      package_state.update!(ds_external_reference: "ds-#{index}")
+    end
+    rule = package.rules.create!(name: "multi-entities test", kind: "multi-entities")
+    rule.decision_tables.create!(
+      content: fixture_content(:scorpio, "decision_table_multi_entities.csv")
+    )
+
+    package.activity_rule.formulas.create!(
+      code:        "org_units_count_exported",
+      description: "org_units_count_exported",
+      expression:  "org_units_count"
+    )
+
+    package.activity_rule.formulas.create!(
+      code:        "org_units_sum_if_count_exported",
+      description: "org_units_sum_if_count_exported",
+      expression:  "org_units_sum_if_count"
+    )
+  end
+
+  def generate_quarterly_values_for(project)
+    refs = project.activities
+                  .flat_map(&:activity_states)
+                  .map(&:external_reference)
+                  .uniq
+                  .reject(&:empty?).sort
+    values = refs.each_with_index.map do |data_element, index|
+      [(1..4).map do |quarter|
+        {
+          dataElement:          data_element,
+          value:                (100 + (index % 2)).to_s,
+          period:               "2015Q#{quarter}",
+          orgUnit:              ORG_UNIT_ID,
+          categoryOptionCombo:  "HllvX50cXC0",
+          attributeOptionCombo: "HllvX50cXC0"
+        }
+      end]
+    end
+
+    values.flatten
+  end
+
+  def create_snaphots(project)
+    return if project.project_anchor.dhis2_snapshots.any?
+
+    stub_organisation_unit_group_sets(project)
+    stub_organisation_unit_groups(project)
+
+    stub_organisation_units(project)
+    stub_data_elements(project)
+    stub_data_elements_groups(project)
+    stub_system_info(project)
+    stub_indicators(project)
+
+    Dhis2SnapshotWorker.new.perform(project.project_anchor.id)
+    WebMock.reset!
+  end
+end


### PR DESCRIPTION
- adding a spec on top of your branch
- mocking some s3 components as tests are using file/disk storage

fix-issues-with-async-deployment :
  -   4385 / 5055 LOC (86.75%) covered.

add-spec-for-simulation : 
  -   4472 / 5053 LOC (88.5%) covered.

tried to expect the simulation values compared to a stored one but looks like the output is not so deterministic to compare nested hash vs nested hash.
