### PR TITLE
Fix various issues with async simulation

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,2 +1,2 @@
 web: bundle exec bin/rails server -p $PORT -e $RAILS_ENV
-worker: bundle exec sidekiq -c $SIDEKIQ_CONCURRENCY
+worker: bundle exec sidekiq -q dhis2-safe -q default -c $SIDEKIQ_CONCURRENCY

--- a/app/controllers/setup/invoices_controller.rb
+++ b/app/controllers/setup/invoices_controller.rb
@@ -85,7 +85,11 @@ class Setup::InvoicesController < PrivateController
       render_legacy_invoice(project, invoicing_request)
     else
       if params[:simulate_async] && Flipper[:use_async_simulation].enabled?(current_user)
-        job = project.project_anchor.invoicing_simulation_jobs.first_or_create(
+
+        job = project.project_anchor.invoicing_simulation_jobs.where(
+          dhis2_period: invoicing_request.period,
+          orgunit_ref:  invoicing_request.entity
+        ).first_or_create(
           dhis2_period: invoicing_request.period,
           orgunit_ref:  invoicing_request.entity
         )

--- a/app/javascript/packs/components/invoice/explanation_row.jsx
+++ b/app/javascript/packs/components/invoice/explanation_row.jsx
@@ -1,6 +1,7 @@
 import humanize from "string-humanize";
 import React from "react";
 import ExplanationSteps from "./explanation_steps";
+
 const backgroundColor = "rgb(253, 250, 249)";
 
 const ExplanationRow = function(props) {

--- a/app/javascript/packs/components/invoice/explanation_row.jsx
+++ b/app/javascript/packs/components/invoice/explanation_row.jsx
@@ -1,11 +1,7 @@
 import humanize from "string-humanize";
 import React from "react";
-
+import ExplanationSteps from "./explanation_steps";
 const backgroundColor = "rgb(253, 250, 249)";
-
-const ExplanationStep = props => (
-  <pre style={{ whiteSpace: "pre-wrap" }}>{props.children}</pre>
-);
 
 const ExplanationRow = function(props) {
   return (
@@ -31,23 +27,7 @@ const ExplanationRow = function(props) {
           </dl>
 
           {props.rowData.instantiated_expression && (
-            <>
-              <h5>Step by step explanations:</h5>
-              {props.rowData.expression && (
-                <ExplanationStep>
-                  {`${props.header} = ${props.rowData.expression}`}
-                </ExplanationStep>
-              )}
-              <ExplanationStep>
-                {`${props.header} = ${props.rowData.instantiated_expression}`}
-              </ExplanationStep>
-              <ExplanationStep>
-                {`${props.header} = ${props.rowData.substituted}`}
-              </ExplanationStep>
-              <ExplanationStep>
-                {`${props.header} = ${props.rowData.solution}`}
-              </ExplanationStep>
-            </>
+            <ExplanationSteps item={props.rowData} variable={props.header} />
           )}
         </div>
       </td>

--- a/app/javascript/packs/components/invoice/explanation_row.jsx
+++ b/app/javascript/packs/components/invoice/explanation_row.jsx
@@ -3,6 +3,10 @@ import React from "react";
 
 const backgroundColor = "rgb(253, 250, 249)";
 
+const ExplanationStep = props => (
+  <pre style={{ whiteSpace: "pre-wrap" }}>{props.children}</pre>
+);
+
 const ExplanationRow = function(props) {
   return (
     <tr key={`explanation-${props.header}`} style={{ backgroundColor }}>
@@ -13,34 +17,36 @@ const ExplanationRow = function(props) {
             <dd>{humanize(props.header)}</dd>
             <dt>Key</dt>
             <dd>{props.rowData.key}</dd>
-            {props.rowData.dhis2_data_element && [
-              <dt>Expression</dt>,
-              <dd>{props.rowData.expression}</dd>,
-            ]}
+
             {props.rowData.state && [
               <dt key="mapping-label">Mapping</dt>,
               <dd key="mapping-value">
-                {props.rowData.state.kind} - {props.rowData.state.ext_id || "" }
+                {props.rowData.state.kind} - {props.rowData.state.ext_id || ""}
               </dd>,
             ]}
             {props.rowData.dhis2_data_element && [
-              <dt>DHIS2-element</dt>,
-              <dd>{props.rowData.dhis2_data_element}</dd>,
+              <dt key="de-label">DHIS2-element</dt>,
+              <dd key="de-value">{props.rowData.dhis2_data_element}</dd>,
             ]}
           </dl>
 
-          {props.rowData.expression && props.rowData.dhis2_data_element && (
+          {props.rowData.instantiated_expression && (
             <>
               <h5>Step by step explanations:</h5>
-              <pre style={{ whiteSpace: "pre-wrap" }}>
+              {props.rowData.expression && (
+                <ExplanationStep>
+                  {`${props.header} = ${props.rowData.expression}`}
+                </ExplanationStep>
+              )}
+              <ExplanationStep>
                 {`${props.header} = ${props.rowData.instantiated_expression}`}
-              </pre>
-              <pre style={{ whiteSpace: "pre-wrap" }}>
+              </ExplanationStep>
+              <ExplanationStep>
                 {`${props.header} = ${props.rowData.substituted}`}
-              </pre>
-              <pre style={{ whiteSpace: "pre-wrap" }}>
+              </ExplanationStep>
+              <ExplanationStep>
                 {`${props.header} = ${props.rowData.solution}`}
-              </pre>
+              </ExplanationStep>
             </>
           )}
         </div>

--- a/app/javascript/packs/components/invoice/explanation_row.jsx
+++ b/app/javascript/packs/components/invoice/explanation_row.jsx
@@ -10,7 +10,7 @@ const ExplanationRow = function(props) {
         <div className="col-sm-9">
           <dl className="dl-horizontal">
             <dt>Name</dt>
-            <dt>{humanize(props.header)}</dt>
+            <dd>{humanize(props.header)}</dd>
             <dt>Key</dt>
             <dd>{props.rowData.key}</dd>
             {props.rowData.dhis2_data_element && [
@@ -18,9 +18,9 @@ const ExplanationRow = function(props) {
               <dd>{props.rowData.expression}</dd>,
             ]}
             {props.rowData.state && [
-              <dt>Mapping</dt>,
-              <dd>
-                {props.rowData.state.kind} - {props.rowData.state.ext_id}
+              <dt key="mapping-label">Mapping</dt>,
+              <dd key="mapping-value">
+                {props.rowData.state.kind} - {props.rowData.state.ext_id || "" }
               </dd>,
             ]}
             {props.rowData.dhis2_data_element && [

--- a/app/javascript/packs/components/invoice/explanation_steps.jsx
+++ b/app/javascript/packs/components/invoice/explanation_steps.jsx
@@ -1,0 +1,39 @@
+import React from "react";
+
+function onlyUnique(value, index, self) {
+  return self.indexOf(value) === index;
+}
+
+const ExplanationStep = props => {
+  if (props.expression == undefined) {
+    return <span />;
+  }
+  return (
+    <pre style={{ whiteSpace: "pre-wrap" }}>{`${props.variable} = ${
+      props.expression
+    }`}</pre>
+  );
+};
+
+const ExplanationSteps = props => {
+  const var_name = props.item.formula || props.variable;
+  // sometimes there no much steps, remove same expression (eg state eval 15 15 15 15 => 15)
+  const steps = [
+    props.item.expression,
+    props.item.instantiated_expression,
+    props.item.substituted,
+    props.item.solution,
+  ].filter(onlyUnique);
+
+  return (
+    <>
+      <h5>Step by step explanations:</h5>
+
+      {steps.map((step, index) => (
+        <ExplanationStep key={index} variable={var_name} expression={step} />
+      ))}
+    </>
+  );
+};
+
+export default ExplanationSteps;

--- a/app/javascript/packs/components/invoice/solution.jsx
+++ b/app/javascript/packs/components/invoice/solution.jsx
@@ -3,10 +3,21 @@ import { numberFormatter } from "../../lib/formatters";
 
 const Solution = function(props) {
   const safeData = props.rowData || {};
-  const formattedSolution = numberFormatter.format(safeData.solution);
+
+  let formattedSolution;
+  let rounded;
+
+  if (safeData.solution === undefined) {
+    formattedSolution = "";
+    rounded = false;
+  } else {
+    formattedSolution = numberFormatter.format(safeData.solution);
+    rounded = parseFloat(formattedSolution) != parseFloat(safeData.solution);
+  }
+
   return (
     <>
-      {parseFloat(formattedSolution) != parseFloat(safeData.solution) && (
+      {rounded && (
         <span
           title={`Rounded for ${safeData.solution}`}
           className="text-danger"

--- a/app/javascript/packs/components/invoice/table.jsx
+++ b/app/javascript/packs/components/invoice/table.jsx
@@ -5,10 +5,16 @@ import TableRow from "./table_row";
 
 const Table = function(props) {
   const invoice = props.invoice;
-  let headers = {};
-  if (invoice.activity_items[0]) {
-    headers = invoice.activity_items[0].cells || {};
-  }
+  let headers = [];
+
+  invoice.activity_items.forEach(activity_item => {
+    Object.keys(activity_item.cells).forEach(state_or_formula => {
+      if (!headers.includes(state_or_formula)) {
+        headers.push(state_or_formula);
+      }
+    });
+  });
+
   let rows = invoice.activity_items;
   rows = rows.sort((a, b) =>
     sortCollator.compare(a.activity.code, b.activity.code),
@@ -19,19 +25,23 @@ const Table = function(props) {
     <table className="table invoice num-span-table table-striped">
       <thead>
         <tr>
-          {Object.keys(headers).map(function(key) {
-            return (
-              <th key={key} title={key}>
-                {humanize(key)}
-              </th>
-            );
-          })}
+          {headers.map(key => (
+            <th key={key} title={key}>
+              {humanize(key)}
+            </th>
+          ))}
           <th>Activity</th>
         </tr>
       </thead>
       <tbody>
         {invoice.activity_items.map(function(row, i) {
-          return <TableRow key={[row.activity.code, i].join("-")} row={row} />;
+          return (
+            <TableRow
+              key={[row.activity.code, i].join("-")}
+              row={row}
+              headers={headers}
+            />
+          );
         })}
       </tbody>
     </table>

--- a/app/javascript/packs/components/invoice/table.jsx
+++ b/app/javascript/packs/components/invoice/table.jsx
@@ -5,7 +5,7 @@ import TableRow from "./table_row";
 
 const Table = function(props) {
   const invoice = props.invoice;
-  let headers = [];
+  const headers = [];
 
   invoice.activity_items.forEach(activity_item => {
     Object.keys(activity_item.cells).forEach(state_or_formula => {

--- a/app/javascript/packs/components/invoice/table_row.jsx
+++ b/app/javascript/packs/components/invoice/table_row.jsx
@@ -27,22 +27,23 @@ class TableRow extends React.Component {
   };
 
   render() {
+    const { row, headers } = this.props;
     const colSpan = Object.keys(this.props.row.cells).length + 1;
     return (
       <>
         <tr key={"row-data"}>
-          {Object.keys(this.props.row.cells).map((key, index) => {
+          {headers.map((key, index) => {
             return (
               <Cell
                 key={key}
                 cellClicked={this.cellClicked}
                 header={key}
                 selected={key == this.state.selectedHeader}
-                rowData={this.props.row.cells[key]}
+                rowData={row.cells[key]}
               />
             );
           })}
-          <td>{this.props.row.activity.name}</td>
+          <td>{row.activity.name}</td>
         </tr>
         {this.state.selectedCell && (
           <ExplanationRow

--- a/app/javascript/packs/components/invoice/total_items.jsx
+++ b/app/javascript/packs/components/invoice/total_items.jsx
@@ -1,26 +1,99 @@
 import humanize from "string-humanize";
 import React from "react";
+import ExplanationSteps from "./explanation_steps";
+import { withStyles } from "@material-ui/core/styles";
+import classNames from "classnames";
 
-const TotalItems = function(props) {
-  if ((props.items || []).length == 0) {
-    return null;
-  }
-  return props.items.map(function(item, i) {
+const selectedColor = "rgb(254, 213, 149)";
+
+const cellStyles = theme => ({
+  selected: {
+    fontWeight: "bold",
+  },
+  selectedIcon: {
+    color: selectedColor,
+    paddingRight: "5px",
+  },
+  selectedSpan: {
+    borderBottom: `1px solid ${selectedColor}`,
+  },
+});
+
+class TotalItem extends React.Component {
+  state = {
+    selected: false,
+  };
+
+  cellClicked = () => {
+    this.setState({ selected: !this.state.selected });
+  };
+
+  render() {
+    const { classes, item } = this.props;
     let value = item.solution;
     if (item.not_exported) {
       value = <del>{value}</del>;
     }
     return (
-      <div key={`total-item${i}`} className="container">
-        <div className="col-md-4">
-          <b>{humanize(item.formula)}</b> :
+      <>
+        <div className="container">
+          <div className="col-md-4">
+            <b>{humanize(item.formula)}</b>:
+          </div>
+          <div
+            className={classNames(
+              "col-md-3",
+              item.is_output ? "formula-output" : "",
+              this.state.selected ? classes.selected : null,
+            )}
+            onClick={this.cellClicked}
+          >
+            {this.state.selected && (
+              <i
+                className={classNames(
+                  "fa fa-info-circle",
+                  classes.selectedIcon,
+                )}
+              />
+            )}
+            <span
+              className={classNames("num-span", {
+                [classes.selectedSpan]: this.state.selected,
+              })}
+            >
+              {value}
+            </span>
+          </div>
         </div>
-        <div className={`col-md-3 ${item.is_output ? "formula-output" : ""}`}>
-          {value}
-        </div>
-      </div>
+        {this.state.selected && (
+          <div>
+            <dl className="dl-horizontal">
+              <dt>Name</dt>
+              <dd>{humanize(item.formula)}</dd>
+              <dt>Key</dt>
+              <dd>{item.key}</dd>
+              <dt>Data element out</dt>
+              <dd>{item.is_output}</dd>
+            </dl>
+            <div className="col-md-10">
+              <div>
+                <ExplanationSteps item={item} />
+              </div>
+            </div>
+          </div>
+        )}
+      </>
     );
-  });
+  }
+}
+
+const TotalItems = props => {
+  if ((props.items || []).length == 0) {
+    return null;
+  }
+  return props.items.map((item, i) => (
+    <TotalItem item={item} key={`total-item${i}`} classes={props.classes} />
+  ));
 };
 
-export default TotalItems;
+export default withStyles(cellStyles)(TotalItems);

--- a/app/javascript/packs/components/invoice/total_items.jsx
+++ b/app/javascript/packs/components/invoice/total_items.jsx
@@ -1,8 +1,8 @@
 import humanize from "string-humanize";
 import React from "react";
-import ExplanationSteps from "./explanation_steps";
 import { withStyles } from "@material-ui/core/styles";
 import classNames from "classnames";
+import ExplanationSteps from "./explanation_steps";
 
 const selectedColor = "rgb(254, 213, 149)";
 

--- a/app/models/invoicing_simulation_job.rb
+++ b/app/models/invoicing_simulation_job.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # == Schema Information
 #
 # Table name: invoicing_jobs
@@ -28,13 +30,15 @@
 #
 
 class InvoicingSimulationJob < InvoicingJob
-
   def self.scope_for(project_anchor)
     project_anchor.invoicing_simulation_jobs
   end
 
   def self.find_invoicing_job(project_anchor, period, orgunit_ref)
-    scope_for(project_anchor).first_or_create(
+    scope_for(project_anchor).where(
+      dhis2_period: period,
+      orgunit_ref:  orgunit_ref
+    ).first_or_create(
       dhis2_period: period,
       orgunit_ref:  orgunit_ref
     )

--- a/lib/invoice_entity_to_json.rb
+++ b/lib/invoice_entity_to_json.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class InvoiceEntityToJson
   attr_accessor :indexed_project
 
@@ -22,10 +24,10 @@ class InvoiceEntityToJson
       invoice_hash(invoice)
     end
     serializable_hash[:dhis2_export_values] = @dhis2_export_values,
-    serializable_hash[:dhis2_input_values] =  @dhis2_input_values
+                                              serializable_hash[:dhis2_input_values] = @dhis2_input_values
     serializable_hash
   end
-  alias_method :to_hash, :serializable_hash
+  alias to_hash serializable_hash
 
   def serialized_json
     ActiveSupport::JSON.encode(serializable_hash)
@@ -40,12 +42,12 @@ class InvoiceEntityToJson
         @invoice_entity.pyramid,
         @invoicing_request.entity
       ).to_h,
-      warnings: contracted?(@invoicing_request, @project) ? nil : non_contracted_orgunit_message(@project)
+      warnings:          contracted?(@invoicing_request, @project) ? nil : non_contracted_orgunit_message(@project)
     }
   end
 
   def invoice_hash(invoice)
-    total_items = invoice.total_items.sort_by {|total_item| total_item.formula.code }.uniq
+    total_items = invoice.total_items.sort_by { |total_item| total_item.formula.code }.uniq
     {
       orgunit_ext_id: invoice.orgunit_ext_id,
       orgunit_name:   pyramid.org_unit(invoice.orgunit_ext_id)&.name,
@@ -55,7 +57,7 @@ class InvoiceEntityToJson
       activity_items: invoice.activity_items.map do |activity_item|
         activity_item_hash(activity_item)
       end,
-      total_items: total_items.map do |total_item|
+      total_items:    total_items.map do |total_item|
         total_item_hash(total_item)
       end
     }
@@ -70,17 +72,19 @@ class InvoiceEntityToJson
       cells:    activity_item.variables.map(&:state).uniq.each_with_object({}) do |code, formulas|
         orbf_var = activity_item.variable(code)
         next unless orbf_var
+
         key = orbf_var.formula&.code || orbf_var.state
         next unless activity_item.solution[key]
+
         activity_state = indexed_project.lookup_activity_state(orbf_var)
         cell = {
           key:                     orbf_var.key,
           instantiated_expression: orbf_var.expression,
           not_exported:            activity_item.not_exported?(key),
           solution:                activity_item.solution[key]&.to_s,
-          substituted:              activity_item.substitued[key],
-          is_input: is_input(activity_item, key),
-          is_output: is_output(activity_item, key)
+          substituted:             activity_item.substitued[key],
+          is_input:                is_input(activity_item, key),
+          is_output:               is_output(activity_item, key)
         }
         if activity_state
           cell[:state] = {
@@ -105,8 +109,8 @@ class InvoiceEntityToJson
       expression:              total_item.explanations[0],
       instantiated_expression: total_item.explanations[2],
       solution:                total_item.value&.to_s,
-      substitued:              total_item.explanations[1],
-      is_output:               total_item.formula.dhis2_mapping,
+      substituted:             total_item.explanations[1],
+      is_output:               total_item.formula.dhis2_mapping
     }
   end
 

--- a/spec/workers/invoice_simulation_worker_spec.rb
+++ b/spec/workers/invoice_simulation_worker_spec.rb
@@ -42,7 +42,7 @@ RSpec.describe InvoiceSimulationWorker do
 
     expect(simulation_json["request"]["warnings"]).to eq(
       "Entity is not in the contracted entity group : Clinic. "\
-      "(Snaphots last updated on 2019-04-29). Only simulation will work. "\
+      "(Snaphots last updated on #{Time.now.to_date}). Only simulation will work. "\
       "Update the group and trigger a dhis2 snaphots. "\
       "Note that it will only fix this issue for current or futur periods."
     )


### PR DESCRIPTION
# 1. Use the same headers in table header and rows (missing cells)

![image](https://user-images.githubusercontent.com/371692/56918494-7e7d9280-6abe-11e9-9ec2-679230a70124.png)


# 2. Display step by step for indicators and data elements too

![image](https://user-images.githubusercontent.com/371692/56918293-e8e20300-6abd-11e9-830e-a2c3aefb591c.png)

# 3. Backend was returning the first simulation (first_or_create)

fix the first_or_create by providing an adequate scope

# 4. Create a sidekiq queue for "read only" dhis2 actions (simulation)

you can then safely start bundle exec sidekiq -q dhis2-safe
on your laptop without the risk of running write workers (data element, dataset creation/modification)

# 5. Show total_item explanations

![image](https://user-images.githubusercontent.com/371692/57073323-0c38c800-6ce1-11e9-87fb-5c83e8626515.png)
