### PR TITLE
Bring async options up to par with normal simulation

### DIFF
--- a/app/controllers/setup/invoices_controller.rb
+++ b/app/controllers/setup/invoices_controller.rb
@@ -242,9 +242,9 @@ class Setup::InvoicesController < PrivateController
     return true if job.id_previously_changed?
     return [false, "This job is still processing"] if job.alive?
 
-    # TODO: Use papertail for a more accurate guess if simulation is outdated.
-    if job.processed_after?(time_stamp: 10.minutes.ago) && force != "strong"
-      [false, "This job was recently processed: #{job.processed_at}, you can force a regeneration with `?force=strong`"]
+    last_change = PaperTrail::Version.where(project_id: current_project).maximum("created_at")
+    if job.processed_after?(time_stamp: last_change) && force != "strong"
+      [false, "This job was recently processed: #{job.processed_at}, you can force a regeneration by checking the checkbox"]
     else
       [true]
     end

--- a/app/controllers/setup/invoices_controller.rb
+++ b/app/controllers/setup/invoices_controller.rb
@@ -241,7 +241,9 @@ class Setup::InvoicesController < PrivateController
     # New jobs always need processing
     return true if job.id_previously_changed?
     return [false, "This job is still processing"] if job.alive?
-    if job.processed_within_last?(interval: 10.minutes) && force != "strong"
+
+    # TODO: Use papertail for a more accurate guess if simulation is outdated.
+    if job.processed_after?(time_stamp: 10.minutes.ago) && force != "strong"
       [false, "This job was recently processed: #{job.processed_at}, you can force a regeneration with `?force=strong`"]
     else
       [true]

--- a/app/controllers/setup/invoices_controller.rb
+++ b/app/controllers/setup/invoices_controller.rb
@@ -95,6 +95,8 @@ class Setup::InvoicesController < PrivateController
         )
         shouldEnqueue, reason = enqueue_simulation_job(job, params[:force])
         if shouldEnqueue
+          # Ensure status of job back is enqueued
+          job.enqueued!
           args = invoicing_request.to_h.merge(simulate_draft: params[:simulate_draft])
           InvoiceSimulationWorker.perform_async(*args.values)
         else

--- a/app/models/invoicing_job.rb
+++ b/app/models/invoicing_job.rb
@@ -97,8 +97,8 @@ class InvoicingJob < ApplicationRecord
     end
   end
 
-  def processed_within_last?(interval: 10.minutes)
-    processed? && processed_at > interval.ago
+  def processed_after?(time_stamp: 10.minutes.ago)
+    processed? && processed_at > time_stamp
   end
 
   def alive?

--- a/app/models/invoicing_request.rb
+++ b/app/models/invoicing_request.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class InvoicingRequest
   include ActiveModel::Model
   include ActiveModel::Validations
@@ -10,7 +12,6 @@ class InvoicingRequest
     super
     @mocked_data ||= [] if mock_values?
   end
-
 
   def start_date_as_date
     year_quarter.start_date
@@ -54,11 +55,12 @@ class InvoicingRequest
 
   def to_h
     {
-      entity: entity,
-      period: period,
-      project_id: project&.id,
-      with_details: with_details,
-      engine_version: engine_version
+      entity:         entity,
+      period:         period,
+      project_id:     project&.id,
+      with_details:   with_details,
+      engine_version: engine_version,
+      mocked_data:    mocked_data
     }
   end
 end

--- a/app/views/setup/invoices/_form.html.erb
+++ b/app/views/setup/invoices/_form.html.erb
@@ -45,6 +45,20 @@
       </div>
     </div>
 
+    <% if Flipper[:use_async_simulation].enabled?(current_user) %>
+      <div class="form-check row">
+        <div class="col-sm-2">
+          <label class="form-check-label col-form-label">
+            Simulate with draft
+          </label>
+        </div>
+
+        <div class="col-sm-10">
+          <%= check_box_tag 'simulate_draft' %>
+        </div>
+      </div>
+    <% end %>
+
     <div class="form-check row">
       <div class="col-sm-2">
         <label class="form-check-label col-form-label">

--- a/app/views/setup/invoices/_form.html.erb
+++ b/app/views/setup/invoices/_form.html.erb
@@ -57,6 +57,18 @@
           <%= check_box_tag 'simulate_draft' %>
         </div>
       </div>
+
+      <div class="form-check row">
+        <div class="col-sm-2">
+          <label class="form-check-label col-form-label">
+            Force regeneration
+          </label>
+        </div>
+
+        <div class="col-sm-10">
+          <%= check_box_tag 'force', 'strong' %>
+        </div>
+      </div>
     <% end %>
 
     <div class="form-check row">

--- a/app/workers/invoice_simulation_worker.rb
+++ b/app/workers/invoice_simulation_worker.rb
@@ -22,10 +22,10 @@ class InvoiceSimulationWorker
   # 3. Serialize to JSON
   # 4. Store on S3
   # 5. Update the job.
-  def perform(entity, period, project_id, with_details, engine_version, simulate_draft)
+  def perform(entity, period, project_id, with_details, engine_version, mocked_data, simulate_draft)
     project = Project.find(project_id)
     InvoicingSimulationJob.execute(project.project_anchor, period, entity) do |job|
-      serialized_json = InvoiceSimulationWorker::Simulation.new(entity, period, project_id, engine_version, with_details, simulate_draft).call
+      serialized_json = InvoiceSimulationWorker::Simulation.new(entity, period, project_id, engine_version, with_details, mocked_data, simulate_draft).call
 
       if job
         name = format("%s.json", [project_id.to_s, entity, period].map(&:underscore).join("-"))
@@ -81,7 +81,7 @@ class InvoiceSimulationWorker
     # version of an `InvoicingReqest`, from there it will build up the
     # original `InvoicingRequest` and then render it to JSON.
     def initialize(*args)
-      @entity, @period, @project_id, @with_details, @engine_version, @simulate_draft = *args
+      @entity, @period, @project_id, @with_details, @engine_version, @mocked_data, @simulate_draft = *args
     end
 
     def call
@@ -103,14 +103,19 @@ class InvoiceSimulationWorker
     end
 
     def invoicing_request
-      @request ||= InvoicingRequest.new(
+      return @request if @request
+
+      request_options = {
         project:        project,
         year:           year,
         quarter:        quarter,
         entity:         @entity,
         with_details:   @with_details,
         engine_version: project.engine_version
-      )
+      }
+      request_options[:mock_values] = "1" if @mocked_data
+
+      @request ||= InvoicingRequest.new(request_options)
     end
 
     def invoicing_options

--- a/app/workers/invoice_simulation_worker.rb
+++ b/app/workers/invoice_simulation_worker.rb
@@ -12,7 +12,7 @@ class InvoiceSimulationWorker
 
   sidekiq_throttle(
     concurrency: { limit: 3 },
-    key_suffix:  ->(_entity, _period, project_id, _with_details, _engine_version, _simulate_draft) { project_id }
+    key_suffix:  ->(_entity, _period, project_id, _with_details, _engine_version, _mocked_data, _simulate_draft) { project_id }
   )
 
   # Roughly these operations will be done:

--- a/config/initializers/rails_admin.rb
+++ b/config/initializers/rails_admin.rb
@@ -16,7 +16,8 @@ RailsAdmin.config do |config|
   ].freeze
 
   config.actions do
-    dashboard
+    dashboard do
+    end
     index
     show_in_app
     export
@@ -59,6 +60,12 @@ RailsAdmin.config do |config|
     end
   end
   config.model "ProjectAnchor" do
+    show do
+      field :program
+      field :token
+      field :projects
+    end
+
     edit do
       field :token
     end
@@ -80,6 +87,14 @@ RailsAdmin.config do |config|
     object_label_method do
       :label
     end
+  end
+
+  config.model "InvoicingJob" do
+    visible { false }
+  end
+
+  config.model "Version" do
+    visible { false }
   end
 
   if ENV["ADMIN_PASSWORD"]

--- a/config/initializers/rails_admin.rb
+++ b/config/initializers/rails_admin.rb
@@ -87,6 +87,11 @@ RailsAdmin.config do |config|
     object_label_method do
       :label
     end
+    show do
+      field :code
+      field :project_anchor
+      field :users
+    end
   end
 
   config.model "InvoicingJob" do

--- a/spec/models/invoicing_job_spec.rb
+++ b/spec/models/invoicing_job_spec.rb
@@ -135,23 +135,23 @@ RSpec.describe InvoicingJob, type: :model do
     end
   end
 
-  describe "processed_within_last?" do
-    it 'true for processed and in interval' do
+  describe "processed_after?" do
+    it 'true for processed and after' do
       job = FactoryBot.build_stubbed(:invoicing_simulation_job, :processed)
       job.processed_at = 9.minutes.ago
-      expect(job.processed_within_last?(interval: 10.minutes)).to eq true
+      expect(job.processed_after?(time_stamp: 10.minutes.ago)).to eq true
     end
 
-    it 'false for processed and outside interval' do
+    it 'false for processed and before timestamp' do
       job = FactoryBot.build_stubbed(:invoicing_simulation_job, :processed)
       job.processed_at = 11.minutes.ago
-      expect(job.processed_within_last?(interval: 10.minutes)).to eq false
+      expect(job.processed_after?(time_stamp: 10.minutes.ago)).to eq false
     end
 
     it 'false for not processed' do
       job = FactoryBot.build_stubbed(:invoicing_simulation_job, :errored)
       job.processed_at = 11.minutes.ago
-      expect(job.processed_within_last?(interval: 10.minutes)).to eq false
+      expect(job.processed_after?(time_stamp: 10.minutes.ago)).to eq false
     end
   end
 

--- a/spec/workers/invoice_simulation_worker_spec.rb
+++ b/spec/workers/invoice_simulation_worker_spec.rb
@@ -37,7 +37,7 @@ RSpec.describe InvoiceSimulationWorker do
       .to_return(status: 200, body: JSON.pretty_generate("dataValues": generate_quarterly_values_for(project)))
 
     simulation_json = with_mocked_s3 do
-      worker.perform(ORG_UNIT_ID, "2015Q1", project.id, true, 3, true)
+      worker.perform(ORG_UNIT_ID, "2015Q1", project.id, true, 3, nil, true)
     end
 
     expect(simulation_json["request"]["warnings"]).to eq(
@@ -54,7 +54,7 @@ RSpec.describe InvoiceSimulationWorker do
 
     with_mocked_s3 do
       begin
-        worker.perform(ORG_UNIT_ID, "2015Q1", project.id, true, 3, true)
+        worker.perform(ORG_UNIT_ID, "2015Q1", project.id, true, 3, nil, true)
       rescue InvoiceSimulationWorker::Simulation::ErrorDuringSimulation => _ignored
       end
     end
@@ -70,7 +70,7 @@ RSpec.describe InvoiceSimulationWorker do
 
     with_mocked_s3 do
       begin
-        worker.perform(ORG_UNIT_ID, "2015Q1", project.id, false, 3, true)
+        worker.perform(ORG_UNIT_ID, "2015Q1", project.id, false, 3, nil, true)
       rescue InvoiceSimulationWorker::Simulation::ErrorDuringSimulation => _ignored
       end
     end


### PR DESCRIPTION
- Bring back mocked values
- Allow user to use draft version
- Use paper trail to determine if simulation needs to reloaded

Looks like ![this](https://pile.pjaspers.com/Screen-Shot-2019-05-15-13-56-27.55-jpIDm4.png)