### PR TITLE
Show the code in activity selection for package creation

### DIFF
--- a/app/views/setup/packages/_form.html.erb
+++ b/app/views/setup/packages/_form.html.erb
@@ -65,9 +65,11 @@
 
 <%= f.association :states, collection: package.project.states, as: :check_boxes %>
 
-<%= f.association :activities, collection: package.project.activities.sort {|a,b| NaturalSort.comparator(a.code, b.code)},
+<%= f.association :activities, collection: package.project.activities.sort {|a,b| NaturalSort.comparator(a.code, b.code)}, :label_method => lambda { |owner| "#{owner.code} | #{owner.name}" },
  input_html: {class: 'sol-powered', data: { selection:"activities_selection", selected: package.project.activities.map(&:id)}} %>
 <div id="activities_selection">
 </div>
 <%= f.input :frequency, collection: Package::FREQUENCIES, as: :select %>
 <%= f.button :submit, class: "btn btn-success" %>
+<br>
+<br><br><br><br><br><br><br>


### PR DESCRIPTION
When a lot different entities and activities, it's hard find the activities back in the list.
Being able to filter on the code might help.

![image](https://user-images.githubusercontent.com/371692/59259441-1e8c1700-8c3a-11e9-9544-39adc06da7d6.png)

