### PR TITLE
Migrate all models to bigint

### DIFF
--- a/app/models/activity.rb
+++ b/app/models/activity.rb
@@ -2,7 +2,7 @@
 #
 # Table name: activities
 #
-#  id         :integer          not null, primary key
+#  id         :bigint(8)        not null, primary key
 #  code       :string
 #  name       :string           not null
 #  short_name :string

--- a/app/models/activity_package.rb
+++ b/app/models/activity_package.rb
@@ -2,7 +2,7 @@
 #
 # Table name: activity_packages
 #
-#  id          :integer          not null, primary key
+#  id          :bigint(8)        not null, primary key
 #  created_at  :datetime         not null
 #  updated_at  :datetime         not null
 #  activity_id :integer          not null

--- a/app/models/activity_state.rb
+++ b/app/models/activity_state.rb
@@ -3,7 +3,7 @@
 #
 # Table name: activity_states
 #
-#  id                 :integer          not null, primary key
+#  id                 :bigint(8)        not null, primary key
 #  external_reference :string
 #  formula            :string
 #  kind               :string           default("data_element"), not null

--- a/app/models/decision_table.rb
+++ b/app/models/decision_table.rb
@@ -2,7 +2,7 @@
 #
 # Table name: decision_tables
 #
-#  id      :integer          not null, primary key
+#  id      :bigint(8)        not null, primary key
 #  content :text
 #  rule_id :integer
 #

--- a/app/models/dhis2_log.rb
+++ b/app/models/dhis2_log.rb
@@ -2,7 +2,7 @@
 #
 # Table name: dhis2_logs
 #
-#  id                :integer          not null, primary key
+#  id                :bigint(8)        not null, primary key
 #  sent              :jsonb
 #  status            :jsonb
 #  created_at        :datetime         not null

--- a/app/models/dhis2_snapshot.rb
+++ b/app/models/dhis2_snapshot.rb
@@ -4,7 +4,7 @@
 #
 # Table name: dhis2_snapshots
 #
-#  id                :integer          not null, primary key
+#  id                :bigint(8)        not null, primary key
 #  content           :jsonb            not null
 #  dhis2_version     :string           not null
 #  kind              :string           not null

--- a/app/models/dhis2_snapshot_change.rb
+++ b/app/models/dhis2_snapshot_change.rb
@@ -2,7 +2,7 @@
 #
 # Table name: dhis2_snapshot_changes
 #
-#  id                :integer          not null, primary key
+#  id                :bigint(8)        not null, primary key
 #  values_after      :jsonb
 #  values_before     :jsonb
 #  whodunnit         :string

--- a/app/models/entity_group.rb
+++ b/app/models/entity_group.rb
@@ -2,7 +2,7 @@
 #
 # Table name: entity_groups
 #
-#  id                              :integer          not null, primary key
+#  id                              :bigint(8)        not null, primary key
 #  external_reference              :string
 #  limit_snaphot_to_active_regions :boolean          default(FALSE), not null
 #  name                            :string

--- a/app/models/formula.rb
+++ b/app/models/formula.rb
@@ -3,7 +3,7 @@
 #
 # Table name: formulas
 #
-#  id                      :integer          not null, primary key
+#  id                      :bigint(8)        not null, primary key
 #  code                    :string           not null
 #  description             :string           not null
 #  exportable_formula_code :string

--- a/app/models/formula_mapping.rb
+++ b/app/models/formula_mapping.rb
@@ -2,7 +2,7 @@
 #
 # Table name: formula_mappings
 #
-#  id                 :integer          not null, primary key
+#  id                 :bigint(8)        not null, primary key
 #  external_reference :string           not null
 #  kind               :string           not null
 #  activity_id        :integer

--- a/app/models/invoicing_job.rb
+++ b/app/models/invoicing_job.rb
@@ -3,7 +3,7 @@
 #
 # Table name: invoicing_jobs
 #
-#  id                :integer          not null, primary key
+#  id                :bigint(8)        not null, primary key
 #  dhis2_period      :string           not null
 #  duration_ms       :integer
 #  errored_at        :datetime

--- a/app/models/invoicing_simulation_job.rb
+++ b/app/models/invoicing_simulation_job.rb
@@ -1,10 +1,9 @@
 # frozen_string_literal: true
-
 # == Schema Information
 #
 # Table name: invoicing_jobs
 #
-#  id                :integer          not null, primary key
+#  id                :bigint(8)        not null, primary key
 #  dhis2_period      :string           not null
 #  duration_ms       :integer
 #  errored_at        :datetime

--- a/app/models/package.rb
+++ b/app/models/package.rb
@@ -4,7 +4,7 @@
 #
 # Table name: packages
 #
-#  id                         :integer          not null, primary key
+#  id                         :bigint(8)        not null, primary key
 #  data_element_group_ext_ref :string           not null
 #  description                :string
 #  frequency                  :string           not null

--- a/app/models/package_entity_group.rb
+++ b/app/models/package_entity_group.rb
@@ -3,7 +3,7 @@
 #
 # Table name: package_entity_groups
 #
-#  id                              :integer          not null, primary key
+#  id                              :bigint(8)        not null, primary key
 #  kind                            :string           default("main"), not null
 #  name                            :string
 #  organisation_unit_group_ext_ref :string

--- a/app/models/package_payment_rule.rb
+++ b/app/models/package_payment_rule.rb
@@ -2,7 +2,7 @@
 #
 # Table name: package_payment_rules
 #
-#  id              :integer          not null, primary key
+#  id              :bigint(8)        not null, primary key
 #  created_at      :datetime         not null
 #  updated_at      :datetime         not null
 #  package_id      :integer          not null

--- a/app/models/package_state.rb
+++ b/app/models/package_state.rb
@@ -1,10 +1,9 @@
 # frozen_string_literal: true
-
 # == Schema Information
 #
 # Table name: package_states
 #
-#  id                     :integer          not null, primary key
+#  id                     :bigint(8)        not null, primary key
 #  de_external_reference  :string
 #  deg_external_reference :string
 #  ds_external_reference  :string

--- a/app/models/payment_rule.rb
+++ b/app/models/payment_rule.rb
@@ -1,10 +1,9 @@
 # frozen_string_literal: true
-
 # == Schema Information
 #
 # Table name: payment_rules
 #
-#  id         :integer          not null, primary key
+#  id         :bigint(8)        not null, primary key
 #  frequency  :string           default("quarterly"), not null
 #  created_at :datetime         not null
 #  updated_at :datetime         not null

--- a/app/models/payment_rule_dataset.rb
+++ b/app/models/payment_rule_dataset.rb
@@ -2,7 +2,7 @@
 #
 # Table name: payment_rule_datasets
 #
-#  id                 :integer          not null, primary key
+#  id                 :bigint(8)        not null, primary key
 #  desynchronized     :boolean
 #  external_reference :string
 #  frequency          :string

--- a/app/models/program.rb
+++ b/app/models/program.rb
@@ -2,7 +2,7 @@
 #
 # Table name: programs
 #
-#  id         :integer          not null, primary key
+#  id         :bigint(8)        not null, primary key
 #  code       :string           not null
 #  created_at :datetime         not null
 #  updated_at :datetime         not null

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -3,7 +3,7 @@
 #
 # Table name: projects
 #
-#  id                    :integer          not null, primary key
+#  id                    :bigint(8)        not null, primary key
 #  boolean               :boolean          default(FALSE)
 #  bypass_ssl            :boolean          default(FALSE)
 #  calendar_name         :string           default("gregorian"), not null

--- a/app/models/project_anchor.rb
+++ b/app/models/project_anchor.rb
@@ -4,7 +4,7 @@
 #
 # Table name: project_anchors
 #
-#  id         :integer          not null, primary key
+#  id         :bigint(8)        not null, primary key
 #  token      :string
 #  created_at :datetime         not null
 #  updated_at :datetime         not null

--- a/app/models/rule.rb
+++ b/app/models/rule.rb
@@ -3,7 +3,7 @@
 #
 # Table name: rules
 #
-#  id              :integer          not null, primary key
+#  id              :bigint(8)        not null, primary key
 #  kind            :string           not null
 #  name            :string           not null
 #  created_at      :datetime         not null

--- a/app/models/state.rb
+++ b/app/models/state.rb
@@ -2,7 +2,7 @@
 #
 # Table name: states
 #
-#  id         :integer          not null, primary key
+#  id         :bigint(8)        not null, primary key
 #  name       :string           not null
 #  short_name :string
 #  created_at :datetime         not null

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -2,7 +2,7 @@
 #
 # Table name: users
 #
-#  id                     :integer          not null, primary key
+#  id                     :bigint(8)        not null, primary key
 #  current_sign_in_at     :datetime
 #  current_sign_in_ip     :inet
 #  email                  :string           default(""), not null

--- a/app/models/version.rb
+++ b/app/models/version.rb
@@ -2,7 +2,7 @@
 #
 # Table name: versions
 #
-#  id             :integer          not null, primary key
+#  id             :bigint(8)        not null, primary key
 #  event          :string           not null
 #  item_type      :string           not null
 #  object         :jsonb

--- a/app/serializers/invoicing_job_serializer.rb
+++ b/app/serializers/invoicing_job_serializer.rb
@@ -4,7 +4,7 @@
 #
 # Table name: invoicing_jobs
 #
-#  id                :integer          not null, primary key
+#  id                :bigint(8)        not null, primary key
 #  dhis2_period      :string           not null
 #  duration_ms       :integer
 #  errored_at        :datetime

--- a/db/migrate/20200004135000_change_id_to_big_ints.rb
+++ b/db/migrate/20200004135000_change_id_to_big_ints.rb
@@ -1,0 +1,33 @@
+class ChangeIdToBigInts < ActiveRecord::Migration[5.2]
+  def change
+    %i[
+      activities
+      activity_packages
+      activity_states
+      decision_tables
+      dhis2_logs
+      dhis2_snapshot_changes
+      dhis2_snapshots
+      entity_groups
+      formula_mappings
+      formulas
+      invoicing_jobs
+      package_entity_groups
+      package_payment_rules
+      package_states
+      packages
+      payment_rule_datasets
+      payment_rules
+      programs
+      project_anchors
+      projects
+      rules
+      states
+      users
+      version_associations
+      versions
+    ].each do |table|
+      change_column table, :id, :bigint
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -38,7 +38,7 @@ ActiveRecord::Schema.define(version: 2020_01_15_140940) do
     t.index ["key"], name: "index_active_storage_blobs_on_key", unique: true
   end
 
-  create_table "activities", id: :serial, force: :cascade do |t|
+  create_table "activities", force: :cascade do |t|
     t.string "name", null: false
     t.integer "project_id", null: false
     t.uuid "stable_id", default: -> { "uuid_generate_v4()" }, null: false
@@ -51,7 +51,7 @@ ActiveRecord::Schema.define(version: 2020_01_15_140940) do
     t.index ["project_id"], name: "index_activities_on_project_id"
   end
 
-  create_table "activity_packages", id: :serial, force: :cascade do |t|
+  create_table "activity_packages", force: :cascade do |t|
     t.integer "activity_id", null: false
     t.integer "package_id", null: false
     t.uuid "stable_id", default: -> { "uuid_generate_v4()" }, null: false
@@ -62,7 +62,7 @@ ActiveRecord::Schema.define(version: 2020_01_15_140940) do
     t.index ["package_id"], name: "index_activity_packages_on_package_id"
   end
 
-  create_table "activity_states", id: :serial, force: :cascade do |t|
+  create_table "activity_states", force: :cascade do |t|
     t.string "external_reference"
     t.string "name", null: false
     t.integer "state_id", null: false
@@ -78,13 +78,13 @@ ActiveRecord::Schema.define(version: 2020_01_15_140940) do
     t.index ["state_id"], name: "index_activity_states_on_state_id"
   end
 
-  create_table "decision_tables", id: :serial, force: :cascade do |t|
+  create_table "decision_tables", force: :cascade do |t|
     t.integer "rule_id"
     t.text "content"
     t.index ["rule_id"], name: "index_decision_tables_on_rule_id"
   end
 
-  create_table "dhis2_logs", id: :serial, force: :cascade do |t|
+  create_table "dhis2_logs", force: :cascade do |t|
     t.jsonb "sent"
     t.jsonb "status"
     t.integer "project_anchor_id"
@@ -93,7 +93,7 @@ ActiveRecord::Schema.define(version: 2020_01_15_140940) do
     t.index ["project_anchor_id"], name: "index_dhis2_logs_on_project_anchor_id"
   end
 
-  create_table "dhis2_snapshot_changes", id: :serial, force: :cascade do |t|
+  create_table "dhis2_snapshot_changes", force: :cascade do |t|
     t.string "dhis2_id", null: false
     t.integer "dhis2_snapshot_id"
     t.jsonb "values_before"
@@ -104,7 +104,7 @@ ActiveRecord::Schema.define(version: 2020_01_15_140940) do
     t.index ["dhis2_snapshot_id"], name: "index_dhis2_snapshot_changes_on_dhis2_snapshot_id"
   end
 
-  create_table "dhis2_snapshots", id: :serial, force: :cascade do |t|
+  create_table "dhis2_snapshots", force: :cascade do |t|
     t.string "kind", null: false
     t.jsonb "content", null: false
     t.integer "project_anchor_id"
@@ -117,7 +117,7 @@ ActiveRecord::Schema.define(version: 2020_01_15_140940) do
     t.index ["project_anchor_id"], name: "index_dhis2_snapshots_on_project_anchor_id"
   end
 
-  create_table "entity_groups", id: :serial, force: :cascade do |t|
+  create_table "entity_groups", force: :cascade do |t|
     t.string "name"
     t.string "external_reference"
     t.integer "project_id"
@@ -143,7 +143,7 @@ ActiveRecord::Schema.define(version: 2020_01_15_140940) do
     t.index ["feature_key", "key", "value"], name: "index_flipper_gates_on_feature_key_and_key_and_value", unique: true
   end
 
-  create_table "formula_mappings", id: :serial, force: :cascade do |t|
+  create_table "formula_mappings", force: :cascade do |t|
     t.integer "formula_id", null: false
     t.integer "activity_id"
     t.string "external_reference", null: false
@@ -152,7 +152,7 @@ ActiveRecord::Schema.define(version: 2020_01_15_140940) do
     t.index ["formula_id"], name: "index_formula_mappings_on_formula_id"
   end
 
-  create_table "formulas", id: :serial, force: :cascade do |t|
+  create_table "formulas", force: :cascade do |t|
     t.string "code", null: false
     t.string "description", null: false
     t.text "expression", null: false
@@ -165,7 +165,7 @@ ActiveRecord::Schema.define(version: 2020_01_15_140940) do
     t.index ["rule_id"], name: "index_formulas_on_rule_id"
   end
 
-  create_table "invoicing_jobs", id: :serial, force: :cascade do |t|
+  create_table "invoicing_jobs", force: :cascade do |t|
     t.integer "project_anchor_id", null: false
     t.string "orgunit_ref", null: false
     t.string "dhis2_period", null: false
@@ -183,7 +183,7 @@ ActiveRecord::Schema.define(version: 2020_01_15_140940) do
     t.index ["project_anchor_id"], name: "index_invoicing_jobs_on_project_anchor_id"
   end
 
-  create_table "package_entity_groups", id: :serial, force: :cascade do |t|
+  create_table "package_entity_groups", force: :cascade do |t|
     t.string "name"
     t.integer "package_id"
     t.string "organisation_unit_group_ext_ref"
@@ -193,7 +193,7 @@ ActiveRecord::Schema.define(version: 2020_01_15_140940) do
     t.index ["package_id"], name: "index_package_entity_groups_on_package_id"
   end
 
-  create_table "package_payment_rules", id: :serial, force: :cascade do |t|
+  create_table "package_payment_rules", force: :cascade do |t|
     t.integer "package_id", null: false
     t.integer "payment_rule_id", null: false
     t.datetime "created_at", null: false
@@ -202,7 +202,7 @@ ActiveRecord::Schema.define(version: 2020_01_15_140940) do
     t.index ["payment_rule_id"], name: "index_package_payment_rules_on_payment_rule_id"
   end
 
-  create_table "package_states", id: :serial, force: :cascade do |t|
+  create_table "package_states", force: :cascade do |t|
     t.integer "package_id"
     t.integer "state_id"
     t.datetime "created_at", null: false
@@ -216,7 +216,7 @@ ActiveRecord::Schema.define(version: 2020_01_15_140940) do
     t.index ["state_id"], name: "index_package_states_on_state_id"
   end
 
-  create_table "packages", id: :serial, force: :cascade do |t|
+  create_table "packages", force: :cascade do |t|
     t.string "name", null: false
     t.string "data_element_group_ext_ref", null: false
     t.string "frequency", null: false
@@ -233,7 +233,7 @@ ActiveRecord::Schema.define(version: 2020_01_15_140940) do
     t.index ["project_id"], name: "index_packages_on_project_id"
   end
 
-  create_table "payment_rule_datasets", id: :serial, force: :cascade do |t|
+  create_table "payment_rule_datasets", force: :cascade do |t|
     t.integer "payment_rule_id"
     t.string "frequency"
     t.string "external_reference"
@@ -246,7 +246,7 @@ ActiveRecord::Schema.define(version: 2020_01_15_140940) do
     t.index ["payment_rule_id"], name: "index_payment_rule_datasets_on_payment_rule_id"
   end
 
-  create_table "payment_rules", id: :serial, force: :cascade do |t|
+  create_table "payment_rules", force: :cascade do |t|
     t.integer "project_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
@@ -254,14 +254,14 @@ ActiveRecord::Schema.define(version: 2020_01_15_140940) do
     t.index ["project_id"], name: "index_payment_rules_on_project_id"
   end
 
-  create_table "programs", id: :serial, force: :cascade do |t|
+  create_table "programs", force: :cascade do |t|
     t.string "code", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["code"], name: "index_programs_on_code", unique: true
   end
 
-  create_table "project_anchors", id: :serial, force: :cascade do |t|
+  create_table "project_anchors", force: :cascade do |t|
     t.integer "program_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
@@ -269,7 +269,7 @@ ActiveRecord::Schema.define(version: 2020_01_15_140940) do
     t.index ["program_id"], name: "index_project_anchors_on_program_id"
   end
 
-  create_table "projects", id: :serial, force: :cascade do |t|
+  create_table "projects", force: :cascade do |t|
     t.string "name", null: false
     t.string "dhis2_url", null: false
     t.string "user"
@@ -292,7 +292,7 @@ ActiveRecord::Schema.define(version: 2020_01_15_140940) do
     t.index ["project_anchor_id"], name: "index_projects_on_project_anchor_id"
   end
 
-  create_table "rules", id: :serial, force: :cascade do |t|
+  create_table "rules", force: :cascade do |t|
     t.string "name", null: false
     t.string "kind", null: false
     t.integer "package_id"
@@ -304,7 +304,7 @@ ActiveRecord::Schema.define(version: 2020_01_15_140940) do
     t.index ["payment_rule_id"], name: "index_rules_on_payment_rule_id"
   end
 
-  create_table "states", id: :serial, force: :cascade do |t|
+  create_table "states", force: :cascade do |t|
     t.string "name", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
@@ -314,7 +314,7 @@ ActiveRecord::Schema.define(version: 2020_01_15_140940) do
     t.index ["project_id"], name: "index_states_on_project_id"
   end
 
-  create_table "users", id: :serial, force: :cascade do |t|
+  create_table "users", force: :cascade do |t|
     t.string "email", default: "", null: false
     t.string "encrypted_password", default: "", null: false
     t.string "reset_password_token"
@@ -333,7 +333,7 @@ ActiveRecord::Schema.define(version: 2020_01_15_140940) do
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end
 
-  create_table "version_associations", id: :serial, force: :cascade do |t|
+  create_table "version_associations", force: :cascade do |t|
     t.integer "version_id"
     t.string "foreign_key_name", null: false
     t.integer "foreign_key_id"
@@ -341,7 +341,7 @@ ActiveRecord::Schema.define(version: 2020_01_15_140940) do
     t.index ["version_id"], name: "index_version_associations_on_version_id"
   end
 
-  create_table "versions", id: :serial, force: :cascade do |t|
+  create_table "versions", force: :cascade do |t|
     t.string "item_type", null: false
     t.integer "item_id", null: false
     t.string "event", null: false

--- a/spec/factories/dhis2_snapshots.rb
+++ b/spec/factories/dhis2_snapshots.rb
@@ -2,7 +2,7 @@
 #
 # Table name: dhis2_snapshots
 #
-#  id                :integer          not null, primary key
+#  id                :bigint(8)        not null, primary key
 #  content           :jsonb            not null
 #  dhis2_version     :string           not null
 #  kind              :string           not null

--- a/spec/factories/invoicing_jobs.rb
+++ b/spec/factories/invoicing_jobs.rb
@@ -2,7 +2,7 @@
 #
 # Table name: invoicing_jobs
 #
-#  id                :integer          not null, primary key
+#  id                :bigint(8)        not null, primary key
 #  dhis2_period      :string           not null
 #  duration_ms       :integer
 #  errored_at        :datetime

--- a/spec/factories/packages.rb
+++ b/spec/factories/packages.rb
@@ -2,7 +2,7 @@
 #
 # Table name: packages
 #
-#  id                         :integer          not null, primary key
+#  id                         :bigint(8)        not null, primary key
 #  data_element_group_ext_ref :string           not null
 #  description                :string
 #  frequency                  :string           not null

--- a/spec/factories/payment_rule_datasets.rb
+++ b/spec/factories/payment_rule_datasets.rb
@@ -2,7 +2,7 @@
 #
 # Table name: payment_rule_datasets
 #
-#  id                 :integer          not null, primary key
+#  id                 :bigint(8)        not null, primary key
 #  desynchronized     :boolean
 #  external_reference :string
 #  frequency          :string

--- a/spec/factories/programs.rb
+++ b/spec/factories/programs.rb
@@ -2,7 +2,7 @@
 #
 # Table name: programs
 #
-#  id         :integer          not null, primary key
+#  id         :bigint(8)        not null, primary key
 #  code       :string           not null
 #  created_at :datetime         not null
 #  updated_at :datetime         not null

--- a/spec/factories/project_anchors.rb
+++ b/spec/factories/project_anchors.rb
@@ -2,7 +2,7 @@
 #
 # Table name: project_anchors
 #
-#  id         :integer          not null, primary key
+#  id         :bigint(8)        not null, primary key
 #  token      :string
 #  created_at :datetime         not null
 #  updated_at :datetime         not null

--- a/spec/factories/projects.rb
+++ b/spec/factories/projects.rb
@@ -2,7 +2,7 @@
 #
 # Table name: projects
 #
-#  id                    :integer          not null, primary key
+#  id                    :bigint(8)        not null, primary key
 #  boolean               :boolean          default(FALSE)
 #  bypass_ssl            :boolean          default(FALSE)
 #  calendar_name         :string           default("gregorian"), not null

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -2,7 +2,7 @@
 #
 # Table name: users
 #
-#  id                     :integer          not null, primary key
+#  id                     :bigint(8)        not null, primary key
 #  current_sign_in_at     :datetime
 #  current_sign_in_ip     :inet
 #  email                  :string           default(""), not null

--- a/spec/models/activity_spec.rb
+++ b/spec/models/activity_spec.rb
@@ -1,10 +1,9 @@
 # frozen_string_literal: true
-
 # == Schema Information
 #
 # Table name: activities
 #
-#  id         :integer          not null, primary key
+#  id         :bigint(8)        not null, primary key
 #  code       :string
 #  name       :string           not null
 #  short_name :string

--- a/spec/models/formula_mapping_spec.rb
+++ b/spec/models/formula_mapping_spec.rb
@@ -2,7 +2,7 @@
 #
 # Table name: formula_mappings
 #
-#  id                 :integer          not null, primary key
+#  id                 :bigint(8)        not null, primary key
 #  external_reference :string           not null
 #  kind               :string           not null
 #  activity_id        :integer

--- a/spec/models/formula_spec.rb
+++ b/spec/models/formula_spec.rb
@@ -1,10 +1,9 @@
 # frozen_string_literal: true
-
 # == Schema Information
 #
 # Table name: formulas
 #
-#  id                      :integer          not null, primary key
+#  id                      :bigint(8)        not null, primary key
 #  code                    :string           not null
 #  description             :string           not null
 #  exportable_formula_code :string

--- a/spec/models/invoicing_job_spec.rb
+++ b/spec/models/invoicing_job_spec.rb
@@ -3,7 +3,7 @@
 #
 # Table name: invoicing_jobs
 #
-#  id                :integer          not null, primary key
+#  id                :bigint(8)        not null, primary key
 #  dhis2_period      :string           not null
 #  duration_ms       :integer
 #  errored_at        :datetime

--- a/spec/models/project_anchor_spec.rb
+++ b/spec/models/project_anchor_spec.rb
@@ -3,7 +3,7 @@
 #
 # Table name: project_anchors
 #
-#  id         :integer          not null, primary key
+#  id         :bigint(8)        not null, primary key
 #  token      :string
 #  created_at :datetime         not null
 #  updated_at :datetime         not null

--- a/spec/models/project_spec.rb
+++ b/spec/models/project_spec.rb
@@ -3,7 +3,7 @@
 #
 # Table name: projects
 #
-#  id                    :integer          not null, primary key
+#  id                    :bigint(8)        not null, primary key
 #  boolean               :boolean          default(FALSE)
 #  bypass_ssl            :boolean          default(FALSE)
 #  calendar_name         :string           default("gregorian"), not null

--- a/spec/models/state_spec.rb
+++ b/spec/models/state_spec.rb
@@ -2,7 +2,7 @@
 #
 # Table name: states
 #
-#  id         :integer          not null, primary key
+#  id         :bigint(8)        not null, primary key
 #  name       :string           not null
 #  short_name :string
 #  created_at :datetime         not null


### PR DESCRIPTION
Against a production dump this looked like this:

```
Migrating to ChangeIdToBigInts (20190619083429)
== 20190619083429 ChangeIdToBigInts: migrating ================================
-- change_column(:activities, :id, :bigint)
   -> 0.1012s
-- change_column(:activity_packages, :id, :bigint)
   -> 0.0114s
-- change_column(:activity_states, :id, :bigint)
   -> 0.0602s
-- change_column(:decision_tables, :id, :bigint)
   -> 0.0077s
-- change_column(:dhis2_logs, :id, :bigint)
   -> 352.7831s
-- change_column(:dhis2_snapshot_changes, :id, :bigint)
   -> 18.2090s
-- change_column(:dhis2_snapshots, :id, :bigint)
   -> 8.3048s
-- change_column(:entity_groups, :id, :bigint)
   -> 0.0172s
-- change_column(:formula_mappings, :id, :bigint)
   -> 0.0264s
-- change_column(:formulas, :id, :bigint)
   -> 0.0209s
-- change_column(:invoicing_jobs, :id, :bigint)
   -> 0.4938s
-- change_column(:package_entity_groups, :id, :bigint)
   -> 0.0187s
-- change_column(:package_payment_rules, :id, :bigint)
   -> 0.0118s
-- change_column(:package_states, :id, :bigint)
   -> 0.0236s
-- change_column(:packages, :id, :bigint)
   -> 0.0763s
-- change_column(:payment_rule_datasets, :id, :bigint)
   -> 0.0102s
-- change_column(:payment_rules, :id, :bigint)
   -> 0.0138s
-- change_column(:programs, :id, :bigint)
   -> 0.1004s
-- change_column(:project_anchors, :id, :bigint)
   -> 0.1661s
-- change_column(:projects, :id, :bigint)
   -> 0.0440s
-- change_column(:rules, :id, :bigint)
   -> 0.0205s
-- change_column(:states, :id, :bigint)
   -> 0.0487s
-- change_column(:users, :id, :bigint)
   -> 0.0081s
-- change_column(:version_associations, :id, :bigint)
   -> 0.1960s
-- change_column(:versions, :id, :bigint)
   -> 0.5729s
== 20190619083429 ChangeIdToBigInts: migrated (381.3504s) =====================
```

~So apart from the dhis2_snapshots taking 7 seconds, it's not really that bad, and I think a downtime of +-10 seconds is acceptable, so Idon't see any reason to do a 2 step dance.~

Edit: Now using a production dump **with** the two large tables in it

A 6 minute migration, so it would require a `maintenance:on` and `ps:scale 0` dance and this should be run in a low traffic window. (Probably this saturday evening).


I also added another thing (it's a single commit, so it can disappear just as quickly, it's just something that I like, but others don't and I don't feel that strongly about it). Clean out old migrations.

1. Move historic migrations from /db/migrate/ to /db/archived_migrations
2. New migration file with current migration version
3. Copy current schema.rb and paste it in change block
4. All done! Migrations are clean again.

So now we have an empty migrations directory again.
