### PR TITLE
Add origin to activity state

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -85,7 +85,7 @@ else
   # We're using both of them against the latest master. We should set
   # them to versions when they become more stable
   gem "hesabu", github: "BLSQ/hesabu"
-  gem "orbf-rules_engine", github: "BLSQ/orbf-rules_engine", branch: "sms/add-support-for-analytics"
+  gem "orbf-rules_engine", github: "BLSQ/orbf-rules_engine"
 end
 # Like a modern code version of the mythical beast with 100 serpent hea...
 # [typhoeus](https://github.com/typhoeus/typhoeus)

--- a/Gemfile
+++ b/Gemfile
@@ -85,7 +85,7 @@ else
   # We're using both of them against the latest master. We should set
   # them to versions when they become more stable
   gem "hesabu", github: "BLSQ/hesabu"
-  gem "orbf-rules_engine", github: "BLSQ/orbf-rules_engine"
+  gem "orbf-rules_engine", github: "BLSQ/orbf-rules_engine", branch: "sms/add-support-for-analytics"
 end
 # Like a modern code version of the mythical beast with 100 serpent hea...
 # [typhoeus](https://github.com/typhoeus/typhoeus)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -7,20 +7,15 @@ GIT
       rest-client
 
 GIT
-  remote: https://github.com/uswitch/rest-client-logger.git
-  revision: 30347f419b6a3a397560fe3947a90956aec28a50
-  specs:
-    rest-client-logger (0.1.0)
-      railties (>= 3.1)
-      rest-client (>= 1.6)
-
-PATH
-  remote: ../hesabu
+  remote: https://github.com/BLSQ/hesabu.git
+  revision: 99b77100edb35ea40cb82b59a0da64008c9d6c2f
   specs:
     hesabu (0.1.14)
 
-PATH
-  remote: ../orbf-rules_engine
+GIT
+  remote: https://github.com/BLSQ/orbf-rules_engine.git
+  revision: c3e4a49a44a34c15253f469740b904af0fab7ad2
+  branch: sms/add-support-for-analytics
   specs:
     orbf-rules_engine (0.1.0)
       activesupport
@@ -29,6 +24,14 @@ PATH
       descriptive_statistics
       dhis2 (= 2.3.8)
       hesabu
+
+GIT
+  remote: https://github.com/uswitch/rest-client-logger.git
+  revision: 30347f419b6a3a397560fe3947a90956aec28a50
+  specs:
+    rest-client-logger (0.1.0)
+      railties (>= 3.1)
+      rest-client (>= 1.6)
 
 GEM
   remote: https://rubygems.org/

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -14,7 +14,7 @@ GIT
 
 GIT
   remote: https://github.com/BLSQ/orbf-rules_engine.git
-  revision: c3e4a49a44a34c15253f469740b904af0fab7ad2
+  revision: 0be0389882d6d90d4564793dec47943bd1ba457b
   branch: sms/add-support-for-analytics
   specs:
     orbf-rules_engine (0.1.0)
@@ -151,7 +151,7 @@ GEM
     diff-lcs (1.3)
     differ (0.1.2)
     docile (1.1.5)
-    domain_name (0.5.20180417)
+    domain_name (0.5.20190701)
       unf (>= 0.0.5, < 1.0.0)
     erubi (1.8.0)
     erubis (2.7.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -7,14 +7,20 @@ GIT
       rest-client
 
 GIT
-  remote: https://github.com/BLSQ/hesabu.git
-  revision: 99b77100edb35ea40cb82b59a0da64008c9d6c2f
+  remote: https://github.com/uswitch/rest-client-logger.git
+  revision: 30347f419b6a3a397560fe3947a90956aec28a50
+  specs:
+    rest-client-logger (0.1.0)
+      railties (>= 3.1)
+      rest-client (>= 1.6)
+
+PATH
+  remote: ../hesabu
   specs:
     hesabu (0.1.14)
 
-GIT
-  remote: https://github.com/BLSQ/orbf-rules_engine.git
-  revision: 86dbbc92828e77f764fdb50c707f65cf9ccf4824
+PATH
+  remote: ../orbf-rules_engine
   specs:
     orbf-rules_engine (0.1.0)
       activesupport
@@ -23,14 +29,6 @@ GIT
       descriptive_statistics
       dhis2 (= 2.3.8)
       hesabu
-
-GIT
-  remote: https://github.com/uswitch/rest-client-logger.git
-  revision: 30347f419b6a3a397560fe3947a90956aec28a50
-  specs:
-    rest-client-logger (0.1.0)
-      railties (>= 3.1)
-      rest-client (>= 1.6)
 
 GEM
   remote: https://rubygems.org/

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -14,8 +14,7 @@ GIT
 
 GIT
   remote: https://github.com/BLSQ/orbf-rules_engine.git
-  revision: 0be0389882d6d90d4564793dec47943bd1ba457b
-  branch: sms/add-support-for-analytics
+  revision: 442a44f84207c722dab4ff63f0eb5bba3c5c86e6
   specs:
     orbf-rules_engine (0.1.0)
       activesupport

--- a/app/controllers/setup/activities_controller.rb
+++ b/app/controllers/setup/activities_controller.rb
@@ -112,6 +112,7 @@ class Setup::ActivitiesController < PrivateController
         external_reference
         kind
         formula
+        origin
         _destroy
       ]
     )

--- a/app/models/activity_state.rb
+++ b/app/models/activity_state.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-
 # == Schema Information
 #
 # Table name: activity_states
@@ -9,6 +8,7 @@
 #  formula            :string
 #  kind               :string           default("data_element"), not null
 #  name               :string           not null
+#  origin             :string           default("dataValueSets")
 #  created_at         :datetime         not null
 #  updated_at         :datetime         not null
 #  activity_id        :integer          not null
@@ -58,9 +58,29 @@ class ActivityState < ApplicationRecord
     message: "%{value} is not a valid see #{KINDS.join(',')}"
   }
 
+  ORIGIN_DATAVALUESETS = "dataValueSets"
+  ORIGIN_ANALYTICS = "analytics"
+  ORIGINS = [
+    ORIGIN_DATAVALUESETS,
+    ORIGIN_ANALYTICS
+  ].freeze
+
+  validates :origin, inclusion: {
+    in:      ORIGINS,
+    message: "%{value} is not a valid see #{ORIGINS.join(',')}"
+  }
+
   def external_reference=(external_reference)
     external_reference = nil if external_reference.blank?
     self[:external_reference] = external_reference
+  end
+
+  def origin_data_value_sets?
+    origin == ORIGIN_DATAVALUESETS
+  end
+
+  def origin_analytics?
+    origin == ORIGIN_ANALYTICS
   end
 
   def kind_data_element?

--- a/app/models/invoicing_request.rb
+++ b/app/models/invoicing_request.rb
@@ -11,6 +11,7 @@ class InvoicingRequest
   def initialize(*)
     super
     @mocked_data ||= [] if mock_values?
+    @mocked_data.each { |v| v["origin"] ||= "dataValueSets" }
   end
 
   def start_date_as_date

--- a/app/models/invoicing_request.rb
+++ b/app/models/invoicing_request.rb
@@ -11,7 +11,7 @@ class InvoicingRequest
   def initialize(*)
     super
     @mocked_data ||= [] if mock_values?
-    @mocked_data.each { |v| v["origin"] ||= "dataValueSets" }
+    @mocked_data.each { |v| v["origin"] ||= "dataValueSets" } if  @mocked_data
   end
 
   def start_date_as_date

--- a/app/models/invoicing_request.rb
+++ b/app/models/invoicing_request.rb
@@ -11,7 +11,7 @@ class InvoicingRequest
   def initialize(*)
     super
     @mocked_data ||= [] if mock_values?
-    @mocked_data.each { |v| v["origin"] ||= "dataValueSets" } if  @mocked_data
+    @mocked_data&.each { |v| v["origin"] ||= "dataValueSets" }
   end
 
   def start_date_as_date

--- a/app/services/map_project_to_orbf_project.rb
+++ b/app/services/map_project_to_orbf_project.rb
@@ -89,7 +89,8 @@ class MapProjectToOrbfProject
         name:    activity_state.name,
         formula: formula,
         kind:    kind,
-        ext_id:  ext_id
+        ext_id:  ext_id,
+        origin:  activity_state.origin
       )
     end
   end

--- a/app/views/setup/activities/_activity_state.html.erb
+++ b/app/views/setup/activities/_activity_state.html.erb
@@ -33,10 +33,9 @@
     <%end%>
   </td>
   <td>
-    <%= f.input("origin", collection:[
+    <%= f.input_field("origin", collection:[
               ["Data value sets api", "dataValueSets"],
               ["Analytics api","analytics"]
-            ],
-            input_html: { style: "width:180px" }) %>
+            ],           style: "width:180px", class:"form-control", include_blank: false, include_hidden: false) %>
   </td>
 </tr>

--- a/app/views/setup/activities/_activity_state.html.erb
+++ b/app/views/setup/activities/_activity_state.html.erb
@@ -1,5 +1,8 @@
 <tr class="nested-fields">
-  <td> <%= activity_state.name %>
+  <td>
+      <%= activity_state.name %>
+      <br/><br/>
+      <i><%= f.object.kind.humanize %></i>
     <% if activity_state.errors.any? %>
     <br>
       <%=icon('fas', "exclamation-triangle", class: "text-danger")%> <% activity_state.errors.full_messages.each do |msg| %>
@@ -9,7 +12,6 @@
    </div>
    <% end %>
   </td>
-    <td> <%= f.object.kind %></td>
   <td> <%= link_to_remove_association icon('fas', "trash-o", class: "text-danger") , f %> </td>
   <td>
     <div class="switch-field pull-right">
@@ -29,5 +31,12 @@
     <%if f.object.kind_formula? %>
       <%= f.text_field :formula %>
     <%end%>
+  </td>
+  <td>
+    <%= f.input("origin", collection:[
+              ["Data value sets api", "dataValueSets"],
+              ["Analytics api","analytics"]
+            ],
+            input_html: { style: "width:180px" }) %>
   </td>
 </tr>

--- a/app/views/setup/activities/_form.html.erb
+++ b/app/views/setup/activities/_form.html.erb
@@ -120,10 +120,10 @@ If they don't exist yet in dhis2, you can create them via this <%= link_to "page
         <thead>
             <tr>
                 <th>Activity</th>
-                <th>Kind</th>
                 <th>Remove</th>
                 <th style="text-align: center;">State</th>
                 <th>Value</th>
+                <th>Origin</th>
             </tr>
         </thead>
         <body>

--- a/app/views/setup/invoices/_activity_item.html.erb
+++ b/app/views/setup/invoices/_activity_item.html.erb
@@ -38,6 +38,7 @@
                       <li> numerator <code><%= @data_compound.indicator(activity_state.ext_id)&.numerator %></code></li>
                       <li><%= link_to_indicator(@current_project,activity_state.ext_id) %></li>
                     <%end%>
+                    <li><%= activity_state.origin %></li>
                   <%end%>
                   <% if variable&.formula&.frequency && (variable.formula.frequency!=variable.formula.rule.package.frequency) %>
                     <li><code><%= variable.formula.frequency %></code></li>

--- a/app/views/setup/setup/_activity.html.erb
+++ b/app/views/setup/setup/_activity.html.erb
@@ -3,7 +3,10 @@
     <td>
       <small>
       <% activity.activity_states.each do |activity_state| %>
-        <li><%= activity_state.name %> (<%= activity_state.state.name %> - <%= activity_state.kind %> <%= activity_state.formula? ? "- #{activity_state.formula}" : ""%> <%if params[:debug] %> - <%= activity_state.external_reference %> <%end%>)</li>
+        <li><%= activity_state.name %> (<%= activity_state.state.name %>
+                                        - <%= activity_state.kind %>
+                                        - <%= activity_state.origin%>
+                                        <%= activity_state.formula? ? "- #{activity_state.formula}" : ""%> <%if params[:debug] %> - <%= activity_state.external_reference %> <%end%>)</li>
       <% end %>
       </small>
   </td>

--- a/app/workers/synchronise_deg_ds_worker.rb
+++ b/app/workers/synchronise_deg_ds_worker.rb
@@ -163,7 +163,7 @@ class SynchroniseDegDsWorker
   end
 
   def indicators_data_element_references(indicators, activity_states)
-    indicator_references = Set.new(activity_states.select(&:kind_indicator?).map(&:external_reference))
+    indicator_references = Set.new(activity_states.select(&:kind_indicator?).select(&:origin_data_value_sets?).map(&:external_reference))
     parser_klazz = Orbf::RulesEngine::IndicatorExpressionParser
     dataelement_references = indicators.select { |i| indicator_references.include?(i.id) }
                                        .map { |indicator| parser_klazz.parse_expression(indicator.numerator) }

--- a/db/migrate/20190703055831_add_origin_to_activity_states.rb
+++ b/db/migrate/20190703055831_add_origin_to_activity_states.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddOriginToActivityStates < ActiveRecord::Migration[5.2]
+  def change
+    add_column :activity_states, :origin, :string, default: "dataValueSets"
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_06_19_063435) do
+ActiveRecord::Schema.define(version: 2019_07_03_055831) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_stat_statements"
@@ -72,6 +72,7 @@ ActiveRecord::Schema.define(version: 2019_06_19_063435) do
     t.datetime "updated_at", null: false
     t.string "kind", default: "data_element", null: false
     t.string "formula"
+    t.string "origin", default: "dataValueSets"
     t.index ["activity_id"], name: "index_activity_states_on_activity_id"
     t.index ["external_reference", "activity_id"], name: "index_activity_states_on_external_reference_and_activity_id", unique: true
     t.index ["state_id"], name: "index_activity_states_on_state_id"


### PR DESCRIPTION
# Context
Not all indicators are "easy to compute" from aggregate data elements.
For example indicators referencing : reporting rates,  constants, program indicators, org unit count.

This clearly open the door to 
   - flexibility : 
       - eg get average statisfaction score from a tracker program and store it in an aggregate/frozen data element
   - troubles : 
        - cycle between data element filled by orbf2 and indicators 
        - extra delays to produce invoices as need a clean analytics run to get latest "satisfaction score"

# Chosen solution 

Allow to assign a "origin" of the data in the activity state mapping

![image](https://user-images.githubusercontent.com/371692/60660226-96271d80-9e57-11e9-8549-aa21d7eb1cbf.png)

and use /api/analytics to calculate invoices

![image](https://user-images.githubusercontent.com/371692/60660280-b7880980-9e57-11e9-89e1-6440b2864326.png)

values that looks like the one in pivot

![image](https://user-images.githubusercontent.com/371692/60660291-bbb42700-9e57-11e9-82fb-e17a2845a10f.png)

# Companion PR in the engine

https://github.com/BLSQ/orbf-rules_engine/pull/54