### PR TITLE
Expose quarterly values to montly packages as well

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ services:
 sudo: false
 language: ruby
 cache: bundler
-before_install: gem install bundler
+before_install: gem install bundler -v '1.17.3'
 before_script:
   - curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter
   - chmod +x ./cc-test-reporter

--- a/app/models/rule_types/activity_rule_type.rb
+++ b/app/models/rule_types/activity_rule_type.rb
@@ -49,6 +49,7 @@ module RuleTypes
       if project&.new_engine?
         var_names.push(*rule.formulas.map { |formula| "#{formula.code}_current_quarter_values" })
         var_names.push(*activity_level_states.map { |formula| "#{formula.code}_current_quarter_quarterly_values" })
+
         if package.monthly?
           (1..12).each do |i|
             monthly_vars = activity_level_states.each_with_object([]) do |formula, result|
@@ -58,7 +59,7 @@ module RuleTypes
           end
         end
 
-        if package.quarterly?
+        if access_to_quarterly_values?
           (1..4).each do |i|
             quarterly_vars = activity_level_states.each_with_object([]) do |formula, result|
               push_window_values(result, formula, "quarters", i)
@@ -96,6 +97,10 @@ module RuleTypes
     end
 
     private
+
+    def access_to_quarterly_values?
+      package.monthly? || package.quarterly?
+    end
 
     def main_orgunit_states
       package_states.map { |state| "#{state.code}_zone_main_orgunit" }

--- a/spec/models/rules_spec.rb
+++ b/spec/models/rules_spec.rb
@@ -1,3 +1,4 @@
+# coding: utf-8
 # frozen_string_literal: true
 
 require "rails_helper"
@@ -333,13 +334,73 @@ RSpec.describe Rule, kind: :model do
        verified_level_4_quarterly
        verified_level_5
        verified_level_5_quarterly
+       %{claimed_is_null_last_1_quarters_exclusive_window_values}
+       %{claimed_is_null_last_1_quarters_window_values}
+       %{claimed_is_null_last_2_quarters_exclusive_window_values}
+       %{claimed_is_null_last_2_quarters_window_values}
+       %{claimed_is_null_last_3_quarters_exclusive_window_values}
+       %{claimed_is_null_last_3_quarters_window_values}
+       %{claimed_is_null_last_4_quarters_exclusive_window_values}
+       %{claimed_is_null_last_4_quarters_window_values}
+       %{claimed_last_1_quarters_exclusive_window_values}
+       %{claimed_last_1_quarters_window_values}
+       %{claimed_last_2_quarters_exclusive_window_values}
+       %{claimed_last_2_quarters_window_values}
+       %{claimed_last_3_quarters_exclusive_window_values}
+       %{claimed_last_3_quarters_window_values}
+       %{claimed_last_4_quarters_exclusive_window_values}
+       %{claimed_last_4_quarters_window_values}
+       %{verified_is_null_last_1_quarters_exclusive_window_values}
+       %{verified_is_null_last_1_quarters_window_values}
+       %{verified_is_null_last_2_quarters_exclusive_window_values}
+       %{verified_is_null_last_2_quarters_window_values}
+       %{verified_is_null_last_3_quarters_exclusive_window_values}
+       %{verified_is_null_last_3_quarters_window_values}
+       %{verified_is_null_last_4_quarters_exclusive_window_values}
+       %{verified_is_null_last_4_quarters_window_values}
+       %{verified_last_1_quarters_exclusive_window_values}
+       %{verified_last_1_quarters_window_values}
+       %{verified_last_2_quarters_exclusive_window_values}
+       %{verified_last_2_quarters_window_values}
+       %{verified_last_3_quarters_exclusive_window_values}
+       %{verified_last_3_quarters_window_values}
+       %{verified_last_4_quarters_exclusive_window_values}
+       %{verified_last_4_quarters_window_values}
+       %{tarif_is_null_last_1_quarters_exclusive_window_values}
+       %{tarif_is_null_last_1_quarters_window_values}
+       %{tarif_is_null_last_2_quarters_exclusive_window_values}
+       %{tarif_is_null_last_2_quarters_window_values}
+       %{tarif_is_null_last_3_quarters_exclusive_window_values}
+       %{tarif_is_null_last_3_quarters_window_values}
+       %{tarif_is_null_last_4_quarters_exclusive_window_values}
+       %{tarif_is_null_last_4_quarters_window_values}
+       %{tarif_last_1_quarters_exclusive_window_values}
+       %{tarif_last_1_quarters_window_values}
+       %{tarif_last_2_quarters_exclusive_window_values}
+       %{tarif_last_2_quarters_window_values}
+       %{tarif_last_3_quarters_exclusive_window_values}
+       %{tarif_last_3_quarters_window_values}
+       %{tarif_last_4_quarters_exclusive_window_values}
+       %{tarif_last_4_quarters_window_values}
     ].freeze
 
     it "should return all states and scoped states " do
       availailable_variables = valid_package_quantity_rule.available_variables
-      expect(availailable_variables).to eq(EXPECTED_VARIABLES), availailable_variables.join("\n")
+      expect(availailable_variables).to match_array(EXPECTED_VARIABLES)
+    end
+
+    it 'allows monthly package to reference quarterly values' do
+      p = project.packages.build(frequency: "monthly")
+      p.states << p.project.states.select { |state| %w[Claimed Verified Tarif].include?(state.name) }.to_a
+      rule = p.rules.build(
+        name: "Test thing",
+        kind: "activity"
+      )
+      vars = rule.available_variables
+      expect(vars).to include("%{verified_is_null_last_1_quarters_window_values}")
     end
   end
+
   describe "validation of formulas" do
     it "should say it's valid for quantity" do
       valid_activity_quantity_rule.valid?
@@ -593,6 +654,22 @@ RSpec.describe Rule, kind: :model do
        %{claimed_last_9_months_window_values}
        %{claimed_previous_year_same_quarter_values}
        %{claimed_previous_year_values}
+       %{claimed_is_null_last_1_quarters_exclusive_window_values}
+       %{claimed_is_null_last_1_quarters_window_values}
+       %{claimed_is_null_last_2_quarters_exclusive_window_values}
+       %{claimed_is_null_last_2_quarters_window_values}
+       %{claimed_is_null_last_3_quarters_exclusive_window_values}
+       %{claimed_is_null_last_3_quarters_window_values}
+       %{claimed_is_null_last_4_quarters_exclusive_window_values}
+       %{claimed_is_null_last_4_quarters_window_values}
+       %{claimed_last_1_quarters_exclusive_window_values}
+       %{claimed_last_1_quarters_window_values}
+       %{claimed_last_2_quarters_exclusive_window_values}
+       %{claimed_last_2_quarters_window_values}
+       %{claimed_last_3_quarters_exclusive_window_values}
+       %{claimed_last_3_quarters_window_values}
+       %{claimed_last_4_quarters_exclusive_window_values}
+       %{claimed_last_4_quarters_window_values}
        attributed_points
        claimed
        claimed_is_null
@@ -612,16 +689,7 @@ RSpec.describe Rule, kind: :model do
        month_of_year
        quarter_of_year
       ]
-      expect(activity_rule.available_variables).to eq(expected), [
-        " got : \n" +
-        activity_rule.available_variables.join("\n"),
-        "\n expected \n ",
-        expected.join("\n"),
-        "\ndiff 1\n",
-        (activity_rule.available_variables - expected).join("\n"),
-        "\n diff 2",
-        (expected - activity_rule.available_variables).join("\n")
-      ].join
+      expect(activity_rule.available_variables).to match_array(expected)
     end
 
     it "has available_variables for zone_activity_rule" do


### PR DESCRIPTION
orbf-rules-engine already can handle these, we were just not exposing
them to the world.

This means that you can now access the last 4 quarters with:

       %{claimed_is_null_last_1_quarters_exclusive_window_values}
       %{claimed_is_null_last_1_quarters_window_values}
       %{claimed_is_null_last_2_quarters_exclusive_window_values}
       %{claimed_is_null_last_2_quarters_window_values}
       %{claimed_is_null_last_3_quarters_exclusive_window_values}
       %{claimed_is_null_last_3_quarters_window_values}
       %{claimed_is_null_last_4_quarters_exclusive_window_values}
       %{claimed_is_null_last_4_quarters_window_values}
       %{claimed_last_1_quarters_exclusive_window_values}
       %{claimed_last_1_quarters_window_values}
       %{claimed_last_2_quarters_exclusive_window_values}
       %{claimed_last_2_quarters_window_values}
       %{claimed_last_3_quarters_exclusive_window_values}
       %{claimed_last_3_quarters_window_values}
       %{claimed_last_4_quarters_exclusive_window_values}
       %{claimed_last_4_quarters_window_values}

ORBF2-235 #close

## Self proof reading checklist

- [x] Did I run Pronto and fixed all warnings (pronto run -c origin/dev)
- [x] Make sure all naming and code will remain understandable in 6 month by someone new to the project or by you.
- [x] Did I test the right thing?
- [x] Did I test corner cases, non happy path (defensive testing)?
- [x] Check that I used the ad-hoc patterns and created files accordingly (Presenters, Services, Search object, Form object,...)
- [x] Check code efficiency with record intensive project
- [x] Update documentation,readme accordingly

Thanks!
