### PR TITLE
Update to bundler 2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ services:
 sudo: false
 language: ruby
 cache: bundler
-before_install: gem install bundler -v '1.17.3'
+before_install: gem install bundler
 before_script:
   - curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter
   - chmod +x ./cc-test-reporter

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -14,7 +14,7 @@ GIT
 
 GIT
   remote: https://github.com/BLSQ/orbf-rules_engine.git
-  revision: 442a44f84207c722dab4ff63f0eb5bba3c5c86e6
+  revision: 72b5004a046e5bd4427f863c1537db4133b0b516
   specs:
     orbf-rules_engine (0.1.0)
       activesupport

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -604,4 +604,4 @@ RUBY VERSION
    ruby 2.5.1p57
 
 BUNDLED WITH
-   1.17.3
+   2.0.2


### PR DESCRIPTION
Updating to being bundled by `bundler` version 2.

This fixes the builds on Travis being broken (or having to hardcode an old version of bundler in the travis.yml)

This also brings in an update to the orbf rules engine, [this commit](https://github.com/BLSQ/orbf-rules_engine/commit/72b5004a046e5bd4427f863c1537db4133b0b516) which looks to add extra info on some error cases, so I'd say safe to merge it in here as well.