### PR TITLE
Developer constraint

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -42,5 +42,6 @@ module Scorpio
     # These are defined in `/lib/*.rb
     require "scorpio"
     require "parallel_dhis2"
+    require "can_access_developer_tools_constraint"
   end
 end

--- a/lib/can_access_developer_tools_constraint.rb
+++ b/lib/can_access_developer_tools_constraint.rb
@@ -1,0 +1,17 @@
+# A constraint to check if a request has access to our developer tools.
+class CanAccessDeveloperToolsConstraint
+  def self.matches?(request)
+    if ActionController::HttpAuthentication::Basic.has_basic_credentials?(request)
+      credentials = ActionController::HttpAuthentication::Basic.decode_credentials(request)
+      email, password = credentials.split(':')
+      email == "admin" && password == ENV["ADMIN_PASSWORD"]
+    else
+      user_id = request.session.fetch("warden.user.user.key", []).flatten.first
+      if user_id && user = User.find(user_id)
+        Scorpio.is_developer?(user)
+      else
+        false
+      end
+    end
+  end
+end

--- a/lib/scorpio.rb
+++ b/lib/scorpio.rb
@@ -1,11 +1,28 @@
 # frozen_string_literal: true
 
 module Scorpio
-  # Development or QA environments will return true
   # rubocop:disable Naming/PredicateName
   # In this case, I think the `is_` actually provides some value
+  #
+  # Returns true if user is a developer or if we are in a development
+  # environment.
+  def self.is_developer?(user)
+    return true if is_dev?
+    return false unless user
+
+    ENV.fetch("DEV_USER_IDS", "").split(",").include?(user.id.to_s)
+  end
+
+  # Development or QA environments will return true
   def self.is_dev?
-    Rails.env.development? || ENV["ORBF_STAGING"]
+    return true if Rails.env.development?
+    return true if ENV["ORBF_STAGING"]
+
+    false
   end
   # rubocop:enable Naming/PredicateName
+
+  def self.can_impersonate?(user)
+    is_developer?(user)
+  end
 end

--- a/spec/lib/scorpio_spec.rb
+++ b/spec/lib/scorpio_spec.rb
@@ -14,4 +14,34 @@ RSpec.describe Scorpio do
       ENV.delete('ORBF_STAGING')
     end
   end
+
+  describe '.is_developer?' do
+    it 'returns true when in dev environment' do
+      expect(Scorpio).to receive(:is_dev?) { true }
+
+      expect(Scorpio.is_developer?(nil)).to eq(true)
+    end
+
+    it 'returns false if no user supplied' do
+      expect(Scorpio).to receive(:is_dev?) { false }
+
+      expect(Scorpio.is_developer?(nil)).to eq(false)
+    end
+
+    it 'returns true in production if user in env variable' do
+      expect(Scorpio).to receive(:is_dev?) { false }
+
+      ENV['DEV_USER_IDS'] = "1,2,3"
+      fake_user = Struct.new(:id).new(3)
+      expect(Scorpio.is_developer?(fake_user)).to eq(true)
+    end
+
+    it 'returns false in production if user not in env variable' do
+      expect(Scorpio).to receive(:is_dev?) { false }
+
+      ENV['DEV_USER_IDS'] = "1,2,3"
+      fake_user = Struct.new(:id).new(5)
+      expect(Scorpio.is_developer?(fake_user)).to eq(false)
+    end
+  end
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -77,6 +77,7 @@ require "devise"
 
 RSpec.configure do |config|
   config.include Devise::Test::ControllerHelpers, type: :controller
+  config.include Devise::Test::IntegrationHelpers, type: :request
 end
 
 require "sidekiq/testing"

--- a/spec/requests/developer_constraints_spec.rb
+++ b/spec/requests/developer_constraints_spec.rb
@@ -1,0 +1,38 @@
+require "rails_helper"
+
+RSpec.describe "DeveloperConstraints", type: :request do
+  it "raises 404 when not signed in" do
+    expect {
+      get '/flipper'
+    }.to raise_error(ActionController::RoutingError)
+  end
+
+  it "resolves with basic auth" do
+    ENV["ADMIN_PASSWORD"] = 'abc123'
+    auth = ActionController::HttpAuthentication::Basic.encode_credentials("admin",ENV["ADMIN_PASSWORD"])
+
+    get '/flipper', headers: { 'HTTP_AUTHORIZATION' => auth }
+
+    expect(response).to have_http_status(:redirect)
+    ENV.delete("ADMIN_PASSWORD")
+  end
+
+  it "resolves with developer user" do
+    user = FactoryBot.create(:user)
+    sign_in user
+    ENV["DEV_USER_IDS"] = "a,b,#{user.id}"
+    get '/flipper'
+
+    expect(response).to have_http_status(:redirect)
+    ENV.delete("DEV_USER_IDS")
+  end
+
+  it "raises 404 with normal user" do
+    user = FactoryBot.create(:user)
+    sign_in user
+
+    expect {
+      get '/flipper'
+    }.to raise_error(ActionController::RoutingError)
+  end
+end


### PR DESCRIPTION
This allows certain users to be whitelisted as developers

      ENV["DEV_USER_IDS"] = "1,2,3"

And have access to the developer tools without having to remember the
admin password.

If you only know the ADMIN_PASSWORD, a curl request with basic
authentication will also still work. But the browser won't prompt you anymore.

## Self proof reading checklist

- [ ] Did I run Pronto and fixed all warnings (pronto run -c origin/dev)
- [ ] Make sure all naming and code will remain understandable in 6 month by someone new to the project or by you.
- [ ] Did I test the right thing?
- [ ] Did I test corner cases, non happy path (defensive testing)?
- [ ] Check that I used the ad-hoc patterns and created files accordingly (Presenters, Services, Search object, Form object,...)
- [ ] Check code efficiency with record intensive project
- [ ] Update documentation,readme accordingly

Thanks!
