### PR TITLE
Add user switcher for devs

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -60,6 +60,10 @@ gem "webpacker", "~> 4.0.1"
 # [devise](https://github.com/plataformatec/devise)
 gem "devise", "~> 4.7.1"
 
+# Log in as another user in Rails
+# [pretender](https://github.com/ankane/pretender)
+gem "pretender", "~> 0.3.4"
+
 ## API related
 
 gem "aws-sdk-s3", "~> 1.30.1"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -280,6 +280,8 @@ GEM
       ast (~> 2.4.0)
     path_expander (1.0.3)
     pg (0.21.0)
+    pretender (0.3.4)
+      actionpack (>= 4.2)
     pronto (0.9.5)
       gitlab (~> 4.0, >= 4.0.0)
       httparty (>= 0.13.7)
@@ -563,6 +565,7 @@ DEPENDENCIES
   paper_trail (~> 10.1.0)
   paper_trail-association_tracking (~> 1.0.0)
   pg (~> 0.18)
+  pretender (~> 0.3.4)
   pronto
   pronto-flay
   pronto-rubocop

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -119,3 +119,15 @@ body.private {
     padding-top: 250px;
   }
 }
+
+.navbar--impersonate {
+  background-color: #fafc56;
+}
+.navbar__impersonate__label {
+  // top bar has min-height of 50, let's copy that here.
+  line-height: 50px;
+}
+
+.navbar__impersonate__label a {
+  color: #fafc56;
+}

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,3 +1,4 @@
 class ApplicationController < ActionController::Base
   protect_from_forgery with: :exception
+  impersonates :user
 end

--- a/app/controllers/private_controller.rb
+++ b/app/controllers/private_controller.rb
@@ -28,4 +28,11 @@ class PrivateController < ApplicationController
     flash[:failure] = "Sorry this project has been published you can't edit it anymore"
     redirect_to setup_project_path(params[:project_id])
   end
+
+  # Override the paper_trail user because we sometimes can be
+  # impersonating someone else, if that's the case, the user who is
+  # impersonating shall be logged.
+  def user_for_paper_trail
+    true_user || current_user
+  end
 end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,0 +1,25 @@
+class UsersController < ApplicationController
+  before_action :authenticate_user!
+  before_action :ensure_dev!
+
+  def index
+    @users = User.order(:id)
+  end
+
+  def impersonate
+    user = User.find(params[:id])
+    impersonate_user(user)
+    redirect_to root_path
+  end
+
+  def stop_impersonating
+    stop_impersonating_user
+    redirect_to root_path
+  end
+
+  private
+
+  def ensure_dev!
+    Scorpio.is_developer?(current_user)
+  end
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -49,6 +49,15 @@ class User < ApplicationRecord
     "User##{id} - #{email}"
   end
 
+  def impersonate_label
+    project = program&.project_anchor&.project
+    if project
+      [id, email, project.name, project.id].join(" - ")
+    else
+      [id, email, "No project assigned"].join(" - ")
+    end
+  end
+
   def flipper_id
     "User:#{id}"
   end

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -1,4 +1,11 @@
-<div class="nav navbar navbar-default navbar-fixed-top">
+<%
+navbar_css_classes = %w(nav navbar navbar-default navbar-fixed-top)
+if true_user && current_user != true_user
+  navbar_css_classes << "navbar--impersonate"
+end
+%>
+
+<div class="<%= navbar_css_classes.join(" ")%>">
   <div class="container">
     <div class="navbar-header">
       <%= link_to root_path, class: "navbar-brand" do %>
@@ -19,6 +26,13 @@
       <div class="navbar-header">
         <%= link_to "Documentation", setup_project_rules_path(@current_project), class: "navbar-brand" %>
       </div>
+      <% if true_user && current_user != true_user %>
+        <div class="navbar-header">
+          <span class="navbar__impersonate__label label label-danger">
+            You are impersonating. <%= link_to "Stop it", stop_impersonating_users_path, method: :post %>
+          </span>
+        </div>
+      <%  end %>
     <% end%>
 
     <div class="collapse navbar-collapse">

--- a/app/views/layouts/private.html.erb
+++ b/app/views/layouts/private.html.erb
@@ -21,5 +21,17 @@
     <div >
       <%= yield %>
     </div>
+    <% if Scorpio.can_impersonate?(true_user || current_user) %>
+      <h5>Sign in as</h5>
+      <details>
+        <div>
+          <ul>
+            <% User.find_each do |user| %>
+              <li><%= link_to user.impersonate_label, impersonate_user_path(user), method: :post %></li>
+            <% end %>
+          </ul>
+        </div>
+      </details>
+    <% end %>
   </body>
 </html>

--- a/config/application.rb
+++ b/config/application.rb
@@ -42,5 +42,6 @@ module Scorpio
     # These are defined in `/lib/*.rb
     require "scorpio"
     require "parallel_dhis2"
+    require "can_access_developer_tools_constraint"
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,6 +6,11 @@ Rails.application.routes.draw do
     mount Sidekiq::Web => "/sidekiq"
     mount Flipper::UI.app(Flipper) => '/flipper'
     Sidekiq::Throttled::Web.enhance_queues_tab!
+
+    resources :users, only: [:index] do
+      post :impersonate, on: :member
+      post :stop_impersonating, on: :collection
+    end
   end
 
   mount RailsAdmin::Engine => "/admin", as: "rails_admin"

--- a/lib/can_access_developer_tools_constraint.rb
+++ b/lib/can_access_developer_tools_constraint.rb
@@ -1,0 +1,17 @@
+# A constraint to check if a request has access to our developer tools.
+class CanAccessDeveloperToolsConstraint
+  def self.matches?(request)
+    if ActionController::HttpAuthentication::Basic.has_basic_credentials?(request)
+      credentials = ActionController::HttpAuthentication::Basic.decode_credentials(request)
+      email, password = credentials.split(':')
+      email == "admin" && password == ENV["ADMIN_PASSWORD"]
+    else
+      user_id = request.session.fetch("warden.user.user.key", []).flatten.first
+      if user_id && user = User.find(user_id)
+        Scorpio.is_developer?(user)
+      else
+        false
+      end
+    end
+  end
+end

--- a/lib/scorpio.rb
+++ b/lib/scorpio.rb
@@ -1,11 +1,28 @@
 # frozen_string_literal: true
 
 module Scorpio
-  # Development or QA environments will return true
   # rubocop:disable Naming/PredicateName
   # In this case, I think the `is_` actually provides some value
+  #
+  # Returns true if user is a developer or if we are in a development
+  # environment.
+  def self.is_developer?(user)
+    return true if is_dev?
+    return false unless user
+
+    ENV.fetch("DEV_USER_IDS", "").split(",").include?(user.id.to_s)
+  end
+
+  # Development or QA environments will return true
   def self.is_dev?
-    Rails.env.development? || ENV["ORBF_STAGING"]
+    return true if Rails.env.development?
+    return true if ENV["ORBF_STAGING"]
+
+    false
   end
   # rubocop:enable Naming/PredicateName
+
+  def self.can_impersonate?(user)
+    is_developer?(user)
+  end
 end

--- a/spec/lib/scorpio_spec.rb
+++ b/spec/lib/scorpio_spec.rb
@@ -14,4 +14,34 @@ RSpec.describe Scorpio do
       ENV.delete('ORBF_STAGING')
     end
   end
+
+  describe '.is_developer?' do
+    it 'returns true when in dev environment' do
+      expect(Scorpio).to receive(:is_dev?) { true }
+
+      expect(Scorpio.is_developer?(nil)).to eq(true)
+    end
+
+    it 'returns false if no user supplied' do
+      expect(Scorpio).to receive(:is_dev?) { false }
+
+      expect(Scorpio.is_developer?(nil)).to eq(false)
+    end
+
+    it 'returns true in production if user in env variable' do
+      expect(Scorpio).to receive(:is_dev?) { false }
+
+      ENV['DEV_USER_IDS'] = "1,2,3"
+      fake_user = Struct.new(:id).new(3)
+      expect(Scorpio.is_developer?(fake_user)).to eq(true)
+    end
+
+    it 'returns false in production if user not in env variable' do
+      expect(Scorpio).to receive(:is_dev?) { false }
+
+      ENV['DEV_USER_IDS'] = "1,2,3"
+      fake_user = Struct.new(:id).new(5)
+      expect(Scorpio.is_developer?(fake_user)).to eq(false)
+    end
+  end
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -77,6 +77,7 @@ require "devise"
 
 RSpec.configure do |config|
   config.include Devise::Test::ControllerHelpers, type: :controller
+  config.include Devise::Test::IntegrationHelpers, type: :request
 end
 
 require "sidekiq/testing"

--- a/spec/requests/developer_constraints_spec.rb
+++ b/spec/requests/developer_constraints_spec.rb
@@ -1,0 +1,38 @@
+require "rails_helper"
+
+RSpec.describe "DeveloperConstraints", type: :request do
+  it "raises 404 when not signed in" do
+    expect {
+      get '/flipper'
+    }.to raise_error(ActionController::RoutingError)
+  end
+
+  it "resolves with basic auth" do
+    ENV["ADMIN_PASSWORD"] = 'abc123'
+    auth = ActionController::HttpAuthentication::Basic.encode_credentials("admin",ENV["ADMIN_PASSWORD"])
+
+    get '/flipper', headers: { 'HTTP_AUTHORIZATION' => auth }
+
+    expect(response).to have_http_status(:redirect)
+    ENV.delete("ADMIN_PASSWORD")
+  end
+
+  it "resolves with developer user" do
+    user = FactoryBot.create(:user)
+    sign_in user
+    ENV["DEV_USER_IDS"] = "a,b,#{user.id}"
+    get '/flipper'
+
+    expect(response).to have_http_status(:redirect)
+    ENV.delete("DEV_USER_IDS")
+  end
+
+  it "raises 404 with normal user" do
+    user = FactoryBot.create(:user)
+    sign_in user
+
+    expect {
+      get '/flipper'
+    }.to raise_error(ActionController::RoutingError)
+  end
+end


### PR DESCRIPTION
Adds a user switching mechanism when:

- In development environment
- In staging environment
- Your user id is in DEV_USER_IDS

It will look like this when impersonating: ![](https://pile.pjaspers.com/Screen-Shot-2019-10-09-12-18-34.14-fjy1DL.png)

The user switcher is just a list in a <details> so looks like this:

![Screenshot 2019-10-09 at 12 27 01](https://user-images.githubusercontent.com/52989/66473708-1df07980-ea90-11e9-9cae-a421f8d78b5f.png)


## Self proof reading checklist

- [ ] Did I run Pronto and fixed all warnings (pronto run -c origin/dev)
- [ ] Make sure all naming and code will remain understandable in 6 month by someone new to the project or by you.
- [ ] Did I test the right thing?
- [ ] Did I test corner cases, non happy path (defensive testing)?
- [ ] Check that I used the ad-hoc patterns and created files accordingly (Presenters, Services, Search object, Form object,...)
- [ ] Check code efficiency with record intensive project
- [ ] Update documentation,readme accordingly

Thanks!
