### PR TITLE
Perf : disable the changelog display on published projects

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ services:
 sudo: false
 language: ruby
 cache: bundler
-before_install: gem install bundler
+before_install: gem install bundler -v 2.0.2
 before_script:
   - curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter
   - chmod +x ./cc-test-reporter

--- a/app/views/setup/setup/_step_publish.html.erb
+++ b/app/views/setup/setup/_step_publish.html.erb
@@ -14,7 +14,6 @@
               <th>Parent Id</th>
               <th>Status</th>
               <th>Publish date</th>
-              <th>Diff (compared to parent)</th>
           </tr>
       </thead>
       <body>
@@ -25,40 +24,6 @@
           <td><%= link_to "#{project.original_id}", setup_project_path(project.original_id) if project.original_id%></td>
           <td><%= project.status %></td>
           <td><%= project.publish_date %></td>
-          <td>
-
-            <% changelog = project.changelog %>
-            <% unless changelog.empty? %>
-            <table class="table">
-              <thead>
-                 <tr>
-                   <th>Operation</th>
-                   <th>What</th>
-                   <th>In this revision</th>
-                   <th>Previously</th>
-              </thead>
-              <body>
-
-            <% changelog.each do |entry| %>
-                  <tr>
-                    <td><%= entry.operation %></td>
-                    <td><%= entry.human_readable_path %></td>
-                    <td>
-                      <%if entry.show_detail && entry.current_value %>
-                        <pre><%= entry.current_value %></pre>
-                      <%end%>
-                    </td>
-                    <td>
-                      <%if entry.show_detail && entry.previous_value%>
-                        <pre><%=entry.previous_value%></pre>
-                      <%end%>
-                    </td>
-                  </tr>
-           <%end%>
-             </body>
-           </table>
-           <%end%>
-          </td>
         </tr>
         <%end%>
       </body>


### PR DESCRIPTION
remove the changelog between "versions" of projects 
as it triggers multiple project loading and select n+1