### PR TITLE
Adapt project look up for a date with publish end date

### DIFF
--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -178,6 +178,7 @@ class Project < ApplicationRecord
   def self.for_date(date)
     where(status: "published")
       .where("projects.publish_date <= ?", date)
+      .where("projects.publish_end_date is null OR projects.publish_end_date >= ?", date)
       .order("projects.publish_date desc")
       .limit(1)
       .first

--- a/db/migrate/20191224083227_add_publish_end_date_to_projects.rb
+++ b/db/migrate/20191224083227_add_publish_end_date_to_projects.rb
@@ -1,0 +1,5 @@
+class AddPublishEndDateToProjects < ActiveRecord::Migration[5.2]
+  def change
+    add_column :projects, :publish_end_date, :datetime
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_09_05_065547) do
+ActiveRecord::Schema.define(version: 2019_12_24_083227) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_stat_statements"
@@ -287,6 +287,7 @@ ActiveRecord::Schema.define(version: 2019_09_05_065547) do
     t.string "qualifier"
     t.string "default_coc_reference"
     t.string "default_aoc_reference"
+    t.datetime "publish_end_date"
     t.index ["project_anchor_id"], name: "index_projects_on_project_anchor_id"
   end
 


### PR DESCRIPTION
* add publish_end_date on project
* adapt query look up by dates

this the behavior with a publish_end date
https://github.com/BLSQ/orbf2/pull/162/files#diff-fb312d8dcf15fea2e04d19523d09ff27R87

```
2012Q1	 => 	7	2012-01-01 00:00:00 UTC	2012-12-31 23:59:59 UTC
2012Q2	 => 	7	2012-01-01 00:00:00 UTC	2012-12-31 23:59:59 UTC
2012Q3	 => 	7	2012-01-01 00:00:00 UTC	2012-12-31 23:59:59 UTC
2012Q4	 => 	7	2012-01-01 00:00:00 UTC	2012-12-31 23:59:59 UTC
2013Q1	 => 	8	2013-01-01 00:00:00 UTC	2014-12-31 23:59:59 UTC
2013Q2	 => 	8	2013-01-01 00:00:00 UTC	2014-12-31 23:59:59 UTC
2014Q3	 => 	8	2013-01-01 00:00:00 UTC	2014-12-31 23:59:59 UTC
2014Q4	 => 	8	2013-01-01 00:00:00 UTC	2014-12-31 23:59:59 UTC
2015Q1   => nil
```