### PR TITLE
add ethiopian calendar support

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -7,14 +7,20 @@ GIT
       rest-client
 
 GIT
-  remote: https://github.com/BLSQ/hesabu.git
-  revision: 3d8c033f081af8b5625d6621438eaf4c4230e97c
+  remote: https://github.com/uswitch/rest-client-logger.git
+  revision: 30347f419b6a3a397560fe3947a90956aec28a50
+  specs:
+    rest-client-logger (0.1.0)
+      railties (>= 3.1)
+      rest-client (>= 1.6)
+
+PATH
+  remote: ../hesabu
   specs:
     hesabu (0.1.14)
 
-GIT
-  remote: https://github.com/BLSQ/orbf-rules_engine.git
-  revision: bd7cd94f7253402a4b3de856a8b4d78383db1193
+PATH
+  remote: ../orbf-rules_engine
   specs:
     orbf-rules_engine (0.1.0)
       activesupport
@@ -23,14 +29,6 @@ GIT
       descriptive_statistics
       dhis2 (= 2.3.8)
       hesabu
-
-GIT
-  remote: https://github.com/uswitch/rest-client-logger.git
-  revision: 30347f419b6a3a397560fe3947a90956aec28a50
-  specs:
-    rest-client-logger (0.1.0)
-      railties (>= 3.1)
-      rest-client (>= 1.6)
 
 GEM
   remote: https://rubygems.org/

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -7,20 +7,14 @@ GIT
       rest-client
 
 GIT
-  remote: https://github.com/uswitch/rest-client-logger.git
-  revision: 30347f419b6a3a397560fe3947a90956aec28a50
-  specs:
-    rest-client-logger (0.1.0)
-      railties (>= 3.1)
-      rest-client (>= 1.6)
-
-PATH
-  remote: ../hesabu
+  remote: https://github.com/BLSQ/hesabu.git
+  revision: 3d8c033f081af8b5625d6621438eaf4c4230e97c
   specs:
     hesabu (0.1.14)
 
-PATH
-  remote: ../orbf-rules_engine
+GIT
+  remote: https://github.com/BLSQ/orbf-rules_engine.git
+  revision: e63425edc108a9115406bbb536ab16dfb6800b53
   specs:
     orbf-rules_engine (0.1.0)
       activesupport
@@ -29,6 +23,14 @@ PATH
       descriptive_statistics
       dhis2 (= 2.3.8)
       hesabu
+
+GIT
+  remote: https://github.com/uswitch/rest-client-logger.git
+  revision: 30347f419b6a3a397560fe3947a90956aec28a50
+  specs:
+    rest-client-logger (0.1.0)
+      railties (>= 3.1)
+      rest-client (>= 1.6)
 
 GEM
   remote: https://rubygems.org/
@@ -203,7 +205,7 @@ GEM
     httparty (0.16.3)
       mime-types (~> 3.0)
       multi_xml (>= 0.5.2)
-    i18n (1.7.0)
+    i18n (1.8.2)
       concurrent-ruby (~> 1.0)
     immigrant (0.3.6)
       activerecord (>= 3.0)
@@ -249,13 +251,13 @@ GEM
       mimemagic (~> 0.3.2)
     memory_profiler (0.9.12)
     method_source (0.9.2)
-    mime-types (3.3)
+    mime-types (3.3.1)
       mime-types-data (~> 3.2015)
     mime-types-data (3.2019.1009)
     mimemagic (0.3.3)
     mini_mime (1.0.1)
     mini_portile2 (2.4.0)
-    minitest (5.13.0)
+    minitest (5.14.0)
     msgpack (1.2.4)
     multi_json (1.13.1)
     multi_xml (0.6.0)
@@ -489,7 +491,7 @@ GEM
     turbolinks-source (5.2.0)
     typhoeus (1.3.1)
       ethon (>= 0.9.0)
-    tzinfo (1.2.5)
+    tzinfo (1.2.6)
       thread_safe (~> 0.1)
     uglifier (4.1.20)
       execjs (>= 0.3.0, < 3)

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-
 # == Schema Information
 #
 # Table name: projects
@@ -7,6 +6,7 @@
 #  id                    :integer          not null, primary key
 #  boolean               :boolean          default(FALSE)
 #  bypass_ssl            :boolean          default(FALSE)
+#  calendar_name         :string           default("gregorian"), not null
 #  cycle                 :string           default("quarterly"), not null
 #  default_aoc_reference :string
 #  default_coc_reference :string

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -15,6 +15,7 @@
 #  name                  :string           not null
 #  password              :string
 #  publish_date          :datetime
+#  publish_end_date      :datetime
 #  qualifier             :string
 #  status                :string           default("draft"), not null
 #  user                  :string
@@ -87,6 +88,14 @@ class Project < ApplicationRecord
 
   def cycle_yearly?
     cycle == "yearly"
+  end
+
+  def calendar
+    @calendar ||= if calendar_name == "ethiopian"
+                    Orbf::RulesEngine::EthiopianCalendar.new
+                  else
+                    Orbf::RulesEngine::GregorianCalendar.new
+                  end
   end
 
   def state(code)

--- a/app/services/invoicing/map_to_invoices.rb
+++ b/app/services/invoicing/map_to_invoices.rb
@@ -10,7 +10,6 @@ module Invoicing
       invoices = print_invoices.select do |invoice|
         selected_periods.include?(invoice.period) && non_empty?(invoice)
       end
-
       invoicing_request.invoices = invoices.sort_by(&:period)
     end
 
@@ -31,7 +30,7 @@ module Invoicing
 
     def selected_periods
       @selected_periods ||= [
-        invoicing_request.year_quarter.months.map(&:to_dhis2),
+        invoicing_request.project.calendar.periods(invoicing_request.year_quarter.to_dhis2, "monthly"),
         invoicing_request.year_quarter.to_dhis2
       ].flatten.to_set
     end

--- a/app/services/map_project_to_orbf_project.rb
+++ b/app/services/map_project_to_orbf_project.rb
@@ -18,7 +18,8 @@ class MapProjectToOrbfProject
       dhis2_params:                          project.dhis_configuration,
       engine_version:                        @engine_version,
       default_category_combo_ext_id:         project.default_coc_reference,
-      default_attribute_option_combo_ext_id: project.default_aoc_reference
+      default_attribute_option_combo_ext_id: project.default_aoc_reference,
+      calendar:                              project.calendar
     )
   end
 

--- a/app/workers/dhis2_snapshot_worker.rb
+++ b/app/workers/dhis2_snapshot_worker.rb
@@ -16,6 +16,9 @@ class Dhis2SnapshotWorker
     @disable_tracking = disable_tracking
     project_anchor = ProjectAnchor.find(project_anchor_id)
 
+    now = project_anchor.projects.first.calendar.from_iso(now.to_date)
+    puts "Snapshoting for #{project_anchor.projects.first.name} : #{now}"
+
     project = project_anchor.projects.for_date(now) || project_anchor.latest_draft
 
     Dhis2Snapshot::KINDS.each do |kind|

--- a/db/migrate/20200115140940_add_calendar_name_to_project.rb
+++ b/db/migrate/20200115140940_add_calendar_name_to_project.rb
@@ -1,0 +1,5 @@
+class AddCalendarNameToProject < ActiveRecord::Migration[5.2]
+  def change
+    add_column :projects, :calendar_name, :string, default: "gregorian", null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_12_24_083227) do
+ActiveRecord::Schema.define(version: 2020_01_15_140940) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_stat_statements"
@@ -288,6 +288,7 @@ ActiveRecord::Schema.define(version: 2019_12_24_083227) do
     t.string "default_coc_reference"
     t.string "default_aoc_reference"
     t.datetime "publish_end_date"
+    t.string "calendar_name", default: "gregorian", null: false
     t.index ["project_anchor_id"], name: "index_projects_on_project_anchor_id"
   end
 

--- a/lib/data_test/verifier.rb
+++ b/lib/data_test/verifier.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 require "fileutils"
 
 module DataTest
@@ -39,16 +40,21 @@ module DataTest
       invoice_entity = Invoicing::InvoiceEntity.new(nil, invoicing_request, options)
       invoice_entity.instance_variable_set(:@pyramid, read_artefact("pyramid", "yml"))
       invoice_entity.instance_variable_set(:@datacompound, read_artefact("data-compound", "yml"))
-      invoice_entity.instance_variable_set(:@orbf_project, read_artefact("project", "yml"))
+      invoice_entity.instance_variable_set(:@orbf_project, read_orbf_project())
       invoice_entity.call
       solver = invoice_entity.fetch_and_solve.solver
       capture_results(solver, invoice_entity.fetch_and_solve.exported_values)
     end
 
+    def read_orbf_project
+      orbf_project = read_artefact("project", "yml")
+      orbf_project.packages.each { |p| p.project = orbf_project }
+      orbf_project.payment_rules.each { |p| p.project = orbf_project }
+      orbf_project
+    end
+
     def ensure_directory_exists
-      unless File.exist? RESULTS_DIR
-        FileUtils.mkdir_p RESULTS_DIR
-      end
+      FileUtils.mkdir_p RESULTS_DIR unless File.exist? RESULTS_DIR
     end
 
     def path_for_result(name, extension)

--- a/lib/tasks/db.rake
+++ b/lib/tasks/db.rake
@@ -17,7 +17,7 @@ namespace :db do
         t.datetime "updated_at",        null: false
         t.index ["project_anchor_id"], name: "index_dhis2_logs_on_project_anchor_id", using: :btree
       end
-      create_table "dhis2_snapshots", id: :serial, force: :cascade do |t|
+      ActiveRecord::Base.connection.create_table "dhis2_snapshots", id: :serial, force: :cascade do |t|
         t.string "kind", null: false
         t.jsonb "content", null: false
         t.integer "project_anchor_id"

--- a/spec/factories/projects.rb
+++ b/spec/factories/projects.rb
@@ -5,6 +5,7 @@
 #  id                    :integer          not null, primary key
 #  boolean               :boolean          default(FALSE)
 #  bypass_ssl            :boolean          default(FALSE)
+#  calendar_name         :string           default("gregorian"), not null
 #  cycle                 :string           default("quarterly"), not null
 #  default_aoc_reference :string
 #  default_coc_reference :string

--- a/spec/factories/projects.rb
+++ b/spec/factories/projects.rb
@@ -13,6 +13,7 @@
 #  name                  :string           not null
 #  password              :string
 #  publish_date          :datetime
+#  publish_end_date      :datetime
 #  qualifier             :string
 #  status                :string           default("draft"), not null
 #  user                  :string

--- a/spec/models/project_spec.rb
+++ b/spec/models/project_spec.rb
@@ -6,6 +6,7 @@
 #  id                    :integer          not null, primary key
 #  boolean               :boolean          default(FALSE)
 #  bypass_ssl            :boolean          default(FALSE)
+#  calendar_name         :string           default("gregorian"), not null
 #  cycle                 :string           default("quarterly"), not null
 #  default_aoc_reference :string
 #  default_coc_reference :string

--- a/spec/models/project_spec.rb
+++ b/spec/models/project_spec.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-
 # == Schema Information
 #
 # Table name: projects
@@ -15,6 +14,7 @@
 #  name                  :string           not null
 #  password              :string
 #  publish_date          :datetime
+#  publish_end_date      :datetime
 #  qualifier             :string
 #  status                :string           default("draft"), not null
 #  user                  :string


### PR DESCRIPTION
https://github.com/BLSQ/orbf-rules_engine/pull/58

This add support for Ethiopian calendar. 
- add a calendar_name on project the default stays gregorian
- the calendar will be passed to the orbf-rules_engine to get the "quarter's month" rights
- the calendar is also used to store the snapshot (eg if snapshoted today will be stored with 2012/05)

As it's specific and allowing people to change it is more "trouble", I opted to just update the calendar name.

Ideally we should get rid of [Periods](https://github.com/BLSQ/orbf2/tree/dev/app/models/periods) but it's still in use in a few places and don't really have time to do it now. Will make an issue about it.
