### PR TITLE
Don't retry on failed equations

### DIFF
--- a/app/workers/invoice_for_project_anchor_worker.rb
+++ b/app/workers/invoice_for_project_anchor_worker.rb
@@ -35,5 +35,13 @@ class InvoiceForProjectAnchorWorker
       invoice_entity = Invoicing::InvoiceEntity.new(project_anchor, request, options)
       invoice_entity.call
     end
+
+  rescue Hesabu::Error => e
+    if e.message =~ /In equation/
+    # The job won't magically heal itself, since the equation
+    # can't compute. This way we keep our queue clean.
+    else
+      fail e
+    end
   end
 end

--- a/spec/workers/invoice_for_project_anchor_worker_spec.rb
+++ b/spec/workers/invoice_for_project_anchor_worker_spec.rb
@@ -323,6 +323,23 @@ RSpec.describe InvoiceForProjectAnchorWorker do
     end
   end
 
+  describe "retry logic" do
+    it "doesn't fail if equation fails" do
+      expect(InvoicingJob).to receive(:execute) { raise Hesabu::Error.new("In equation and so on")}
+      expect {
+        worker.perform(project.project_anchor.id, 2015, 1, ["Rp268JB6Ne4"])
+      }.to_not raise_error
+
+    end
+
+    it 'fails if hesabu error other than equation fails' do
+      expect(InvoicingJob).to receive(:execute) { raise Hesabu::Error.new("Some error in Hesabu")}
+
+      expect {
+        worker.perform(project.project_anchor.id, 2015, 1, ["Rp268JB6Ne4"])
+      }.to raise_error(Hesabu::Error, "Some error in Hesabu")
+    end
+  end
   def stub_dhis2_values_yearly(values, start_date)
     stub_request(:get, "http://play.dhis2.org/demo/api/dataValueSets?children=false&endDate=2015-12-31&orgUnit=vRC0stJ5y9Q&startDate=#{start_date}")
       .to_return(status: 200, body: values)


### PR DESCRIPTION
The downside is that we won't notice them anymore, the upside is that the queue stays clean (for now)

I'll work on something to help us keep noticing them, but it might be a good idea to deploy this to avoid the queue congestion.
