### PR TITLE
Smaller snapshot pageSize, clean geometry field, speediest autocomple…

### DIFF
--- a/app/controllers/setup/autocomplete_controller.rb
+++ b/app/controllers/setup/autocomplete_controller.rb
@@ -5,7 +5,8 @@ class Setup::AutocompleteController < PrivateController
     if params.key?(:term)
       organisation_unit_group_by_term_on_sol
     elsif params.key?(:siblings)
-      organisation_unit_group_by_used_or_sibling_id
+      results = search_results(nil, "organisation_unit_groups")
+      render_sol_items(results, nil)
     else
       render_sol_items([])
     end

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -284,7 +284,7 @@ class Project < ApplicationRecord
       user:                user,
       password:            password,
       no_ssl_verification: bypass_ssl,
-      debug:               false
+      debug:               true
     }
   end
 

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -284,7 +284,7 @@ class Project < ApplicationRecord
       user:                user,
       password:            password,
       no_ssl_verification: bypass_ssl,
-      debug:               true
+      debug:               false
     }
   end
 

--- a/app/workers/dhis2_snapshot_compactor.rb
+++ b/app/workers/dhis2_snapshot_compactor.rb
@@ -4,7 +4,7 @@
 
 class Dhis2SnapshotCompactor
   CLEANUP_INFOS = {
-    "organisation_units" => %w[client coordinates access attribute_values users data_sets user_group_accesses],
+    "organisation_units" => %w[client coordinates geometry access attribute_values users data_sets user_group_accesses],
     "data_elements"      => %w[access client user user_group_accesses]
   }.freeze
 

--- a/app/workers/dhis2_snapshot_worker.rb
+++ b/app/workers/dhis2_snapshot_worker.rb
@@ -5,7 +5,7 @@ class Dhis2SnapshotWorker
   include Sidekiq::Throttled::Worker
   sidekiq_options retry: 5
 
-  PAGE_SIZE = 5000
+  PAGE_SIZE = 1000
 
   sidekiq_throttle(
     concurrency: { limit: 1 },
@@ -67,12 +67,12 @@ class Dhis2SnapshotWorker
 
   ORGANISATION_UNITS_FIELDS = [
     ":all",
-    "!coordinates", "!ancestors", "!access", "!attributeValues", "!users",
+    "!coordinates", "!ancestors", "!access", "!attributeValues", "!users", "!geometry",
     "!dataSets", "!userGroupAccesses", "!dimensionItemType", "!externalAccess"
   ].join(",")
 
   def fetch_data(project, kind)
-    fetcher(project, kind).fetch_data(project, kind)
+    fetcher(project, kind).fetch_data(project, kind, page_size: PAGE_SIZE)
   end
 
   def fetcher(project, kind)

--- a/app/workers/fetchers/organisation_units_snapshot_fetcher.rb
+++ b/app/workers/fetchers/organisation_units_snapshot_fetcher.rb
@@ -6,11 +6,11 @@ module Fetchers
       @fetcher = GenericSnapshotFetcher.new(fields: fields)
     end
 
-    def fetch_data(project, kind)
+    def fetch_data(project, kind, params)
       raise "OrganisationUnitsSnapshotFetcher works only on organisation_units" unless kind == :organisation_units
       filters = build_filters(project)
       filters.each_with_object([]) do |filter, data|
-        data.push(*fetcher.fetch_data(project, kind, filter: filter))
+        data.push(*fetcher.fetch_data(project, kind, {filter: filter}.merge(params)))
       end
     end
 

--- a/spec/controllers/api/v2/org_units_controller_spec.rb
+++ b/spec/controllers/api/v2/org_units_controller_spec.rb
@@ -3,7 +3,7 @@
 require "rails_helper"
 
 def stub_dhis2_orgunits_fetch(project)
-  stub_request(:get, "#{project.dhis2_url}/api/organisationUnits?fields=:all&pageSize=5000")
+  stub_request(:get, "#{project.dhis2_url}/api/organisationUnits?fields=:all&pageSize=#{Dhis2SnapshotWorker::PAGE_SIZE}")
     .to_return(
       status: 200,
       body:   fixture_content(:dhis2, "all_organisation_units_with_groups.json")

--- a/spec/controllers/api/v2/sets_controller_spec.rb
+++ b/spec/controllers/api/v2/sets_controller_spec.rb
@@ -3,7 +3,7 @@
 require "rails_helper"
 
 def stub_dhis2_orgunits_fetch(project)
-  stub_request(:get, "#{project.dhis2_url}/api/organisationUnits?fields=:all&pageSize=5000")
+  stub_request(:get, "#{project.dhis2_url}/api/organisationUnits?fields=:all&pageSize=#{Dhis2SnapshotWorker::PAGE_SIZE}")
     .to_return(
       status: 200,
       body:   fixture_content(:dhis2, "all_organisation_units_with_groups.json")

--- a/spec/controllers/setup/activities_controller_spec.rb
+++ b/spec/controllers/setup/activities_controller_spec.rb
@@ -161,17 +161,17 @@ RSpec.describe Setup::ActivitiesController, type: :controller do
       end
 
       def stub_data_compound
-        stub_request(:get, "http://play.dhis2.org/demo/api/dataElements?fields=:all&pageSize=5000")
+        stub_request(:get, "http://play.dhis2.org/demo/api/dataElements?fields=:all&pageSize=#{Dhis2SnapshotWorker::PAGE_SIZE}")
           .to_return(status: 200, body: {
             dataElements: [{
               id:   "deid",
               name: "de name from dhis2"
             }]
           }.to_json)
-        stub_request(:get, "http://play.dhis2.org/demo/api/dataElementGroups?fields=:all&pageSize=5000").to_return(status: 200, body: {
+        stub_request(:get, "http://play.dhis2.org/demo/api/dataElementGroups?fields=:all&pageSize=#{Dhis2SnapshotWorker::PAGE_SIZE}").to_return(status: 200, body: {
           dataElementGroups: []
         }.to_json)
-        stub_request(:get, "http://play.dhis2.org/demo/api/indicators?fields=:all&pageSize=5000").to_return(status: 200, body: {
+        stub_request(:get, "http://play.dhis2.org/demo/api/indicators?fields=:all&pageSize=#{Dhis2SnapshotWorker::PAGE_SIZE}").to_return(status: 200, body: {
           indicators: [{
             id:   "indicatorid",
             name: "indicator name from dhis2"

--- a/spec/workers/dhis2_snapshot_fixture.rb
+++ b/spec/workers/dhis2_snapshot_fixture.rb
@@ -28,18 +28,22 @@ module Dhis2SnapshotFixture
       .to_return(status: 200, body: fixture_content(:dhis2, "data_element_groups.json"))
   end
 
-  def stub_indicators(_project)
-    stub_request(:get, "http://play.dhis2.org/demo/api/indicators?fields=:all&pageSize=#{Dhis2SnapshotWorker::PAGE_SIZE}")
+  def stub_indicators(project)
+    stub_request(:get, "#{project.dhis2_url}/api/indicators?fields=:all&pageSize=#{Dhis2SnapshotWorker::PAGE_SIZE}")
       .to_return(status: 200, body: fixture_content(:dhis2, "indicators.json"))
   end
 
-  def stub_organisation_unit_group_sets(_project)
-    stub_request(:get, "http://play.dhis2.org/demo/api/organisationUnitGroupSets?fields=:all&pageSize=#{Dhis2SnapshotWorker::PAGE_SIZE}")
+  def stub_organisation_unit_group_sets(project)
+    stub_request(:get, "#{project.dhis2_url}/api/organisationUnitGroupSets?fields=:all&pageSize=#{Dhis2SnapshotWorker::PAGE_SIZE}")
       .to_return(status: 200, body: fixture_content(:dhis2, "organisation_unit_group_sets.json"))
   end
 
-  def stub_category_combos(_project)
-    stub_request(:get, "http://play.dhis2.org/demo/api/categoryCombos?fields=id,name,code,categoryOptionCombos[id,name,code]&pageSize=5000").to_return(status: 200, body: fixture_content(:dhis2, "category_combos.json"))
+  def stub_category_combos(project)
+    stub_request(:get, "#{project.dhis2_url}/api/categoryCombos?fields=id,name,code,categoryOptionCombos[id,name,code]&pageSize=#{Dhis2SnapshotWorker::PAGE_SIZE}").to_return(status: 200, body: fixture_content(:dhis2, "category_combos.json"))
+  end
+
+  def stub_all_snapshots(project, month = "201803")
+    stub_snapshots(project, month)
   end
 
   def stub_snapshots(project, month = "201803")

--- a/spec/workers/dhis2_snapshot_worker_spec.rb
+++ b/spec/workers/dhis2_snapshot_worker_spec.rb
@@ -67,7 +67,7 @@ RSpec.describe Dhis2SnapshotWorker do
 
   describe "active regions" do
     FIELDS = "?fields=:all,!coordinates,!ancestors,!access,!attributeValues,"\
-                "!users,!dataSets,!userGroupAccesses,!dimensionItemType,!externalAccess"
+                "!users,!geometry,!dataSets,!userGroupAccesses,!dimensionItemType,!externalAccess"
     let(:target_group_id) { "targetgroupid" }
     let(:pager) {
       {
@@ -122,7 +122,7 @@ RSpec.describe Dhis2SnapshotWorker do
       stub_request(:get, "http://play.dhis2.org/demo/api/organisationUnits" +
                           FIELDS +
                           "&filter=path:like:/ImspTQPwCqd/" + id +
-                          "&pageSize=5000")
+                          "&pageSize=#{Dhis2SnapshotWorker::PAGE_SIZE}")
         .to_return(
           status: 200,
           body:   JSON.pretty_generate(
@@ -137,7 +137,7 @@ RSpec.describe Dhis2SnapshotWorker do
     def stub_country
       stub_request(:get, "http://play.dhis2.org/demo/api/organisationUnits" +
                           FIELDS +
-                          "&filter=path:eq:/ImspTQPwCqd&pageSize=5000")
+                          "&filter=path:eq:/ImspTQPwCqd&pageSize=#{Dhis2SnapshotWorker::PAGE_SIZE}")
         .to_return(
           status: 200,
           body:   JSON.pretty_generate(


### PR DESCRIPTION
* smaller snapshot pageSize (timeout on large instances)
* exclude geometry field from snapshots
* make autocomplete for orgunit groups faster and remove siblings condition (no need to setup orgunits upfront)

## Self proof reading checklist

- [ ] Did I run Pronto and fixed all warnings (pronto run -c origin/dev)
- [ ] Make sure all naming and code will remain understandable in 6 month by someone new to the project or by you.
- [ ] Did I test the right thing?
- [ ] Did I test corner cases, non happy path (defensive testing)?
- [ ] Check that I used the ad-hoc patterns and created files accordingly (Presenters, Services, Search object, Form object,...)
- [ ] Check code efficiency with record intensive project
- [ ] Update documentation,readme accordingly

Thanks!
