### PR TITLE
Add support for contracts

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ env:
     - GIT_COMMITTED_AT=$(if [ "$TRAVIS_PULL_REQUEST" == "false" ]; then git log -1 --pretty=format:%ct; else git log -1 --skip 1 --pretty=format:%ct; fi)
     - RAILS_ENV=test
 addons:
-  postgresql: "9.6"
+  postgresql: "11.7"
   chrome: stable
   apt:
     packages:
@@ -14,13 +14,19 @@ sudo: false
 language: ruby
 cache: bundler
 before_install:
-  - gem install bundler -v 2.0.2
+  - gem install bundler -v 2.1.4
 before_script:
   - curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter
   - chmod +x ./cc-test-reporter
   - cp config/database-travis.yml config/database.yml
   - psql -c 'create database orbf2_test;' -U postgres
-  - ln --symbolic /usr/lib/chromium-browser/chromedriver "${HOME}/bin/chromedriver"
+  - version=$(curl -s https://chromedriver.storage.googleapis.com/LATEST_RELEASE)
+  - wget -N https://chromedriver.storage.googleapis.com/$version/chromedriver_linux64.zip -P ~/
+  - unzip ~/chromedriver_linux64.zip -d ~/
+  - rm ~/chromedriver_linux64.zip
+  - sudo mv -f ~/chromedriver /usr/local/share/
+  - sudo chmod +x /usr/local/share/chromedriver
+  - sudo ln -s /usr/local/share/chromedriver /usr/local/bin/chromedriver
 script:
   - echo "O HAI"
   - script/cibuild

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ env:
     - GIT_COMMITTED_AT=$(if [ "$TRAVIS_PULL_REQUEST" == "false" ]; then git log -1 --pretty=format:%ct; else git log -1 --skip 1 --pretty=format:%ct; fi)
     - RAILS_ENV=test
 addons:
-  postgresql: "11.7"
+  postgresql: "9.6"
   chrome: stable
   apt:
     packages:
@@ -21,6 +21,7 @@ before_script:
   - cp config/database-travis.yml config/database.yml
   - psql -c 'create database orbf2_test;' -U postgres
   - version=$(curl -s https://chromedriver.storage.googleapis.com/LATEST_RELEASE)
+  - google-chrome --version
   - wget -N https://chromedriver.storage.googleapis.com/$version/chromedriver_linux64.zip -P ~/
   - unzip ~/chromedriver_linux64.zip -d ~/
   - rm ~/chromedriver_linux64.zip

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,6 @@ sudo: false
 language: ruby
 cache: bundler
 before_install:
-  - gem uninstall bundler
   - gem install bundler -v 2.0.2
 before_script:
   - curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter

--- a/Gemfile
+++ b/Gemfile
@@ -113,7 +113,7 @@ group :development, :test do
   gem "ruby-prof"
   gem "shoulda-matchers", require: false
 
-  gem "capybara", "~> 3.12.0"
+  gem "capybara"
   gem "json-diff", "~> 0.4.1"
   gem "rubyzip", "~> 1.3.0"
   gem "selenium-webdriver"

--- a/Gemfile
+++ b/Gemfile
@@ -116,7 +116,7 @@ group :development, :test do
   gem "capybara", "~> 3.12.0"
   gem "json-diff", "~> 0.4.1"
   gem "rubyzip", "~> 1.3.0"
-  gem "selenium-webdriver", "~> 3.142.3"
+  gem "selenium-webdriver"
 end
 
 group :development do

--- a/Gemfile
+++ b/Gemfile
@@ -89,7 +89,7 @@ else
   # We're using both of them against the latest master. We should set
   # them to versions when they become more stable
   gem "hesabu", github: "BLSQ/hesabu"
-  gem "orbf-rules_engine", github: "BLSQ/orbf-rules_engine"
+  gem "orbf-rules_engine", github: "BLSQ/orbf-rules_engine", branch: "contracts-support" #TODO use master
 end
 # Like a modern code version of the mythical beast with 100 serpent hea...
 # [typhoeus](https://github.com/typhoeus/typhoeus)

--- a/Gemfile
+++ b/Gemfile
@@ -89,7 +89,7 @@ else
   # We're using both of them against the latest master. We should set
   # them to versions when they become more stable
   gem "hesabu", github: "BLSQ/hesabu"
-  gem "orbf-rules_engine", github: "BLSQ/orbf-rules_engine", branch: "contracts-support" #TODO use master
+  gem "orbf-rules_engine", github: "BLSQ/orbf-rules_engine", branch: "master"
 end
 # Like a modern code version of the mythical beast with 100 serpent hea...
 # [typhoeus](https://github.com/typhoeus/typhoeus)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -112,13 +112,13 @@ GEM
       sassc (>= 2.0.0)
     builder (3.2.4)
     byebug (10.0.2)
-    capybara (3.12.0)
+    capybara (3.33.0)
       addressable
       mini_mime (>= 0.1.3)
       nokogiri (~> 1.8)
       rack (>= 1.6.0)
       rack-test (>= 0.6.3)
-      regexp_parser (~> 1.2)
+      regexp_parser (~> 1.5)
       xpath (~> 3.2)
     childprocess (3.0.0)
     cocoon (1.2.12)
@@ -255,7 +255,7 @@ GEM
       mime-types-data (~> 3.2015)
     mime-types-data (3.2020.0512)
     mimemagic (0.3.3)
-    mini_mime (1.0.1)
+    mini_mime (1.0.2)
     mini_portile2 (2.4.0)
     minitest (5.14.1)
     msgpack (1.2.4)
@@ -266,7 +266,7 @@ GEM
     nested_form (0.3.2)
     netrc (0.11.0)
     nio4r (2.3.1)
-    nokogiri (1.10.8)
+    nokogiri (1.10.9)
       mini_portile2 (~> 2.4.0)
     octokit (4.13.0)
       sawyer (~> 0.8.0, >= 0.5.3)
@@ -303,9 +303,9 @@ GEM
       method_source (~> 0.9.0)
     pry-rails (0.3.9)
       pry (>= 0.10.4)
-    public_suffix (3.0.3)
+    public_suffix (3.1.1)
     puma (3.12.4)
-    rack (2.0.8)
+    rack (2.2.3)
     rack-mini-profiler (1.0.1)
       rack (>= 1.2.0)
     rack-pjax (1.0.0)
@@ -368,7 +368,7 @@ GEM
       ffi (~> 1.0)
     redis (4.0.3)
     redis-prescription (1.0.0)
-    regexp_parser (1.3.0)
+    regexp_parser (1.7.1)
     remotipart (1.4.2)
     request_store (1.4.1)
       rack (>= 1.4)
@@ -530,7 +530,7 @@ DEPENDENCIES
   bootstrap-datepicker-rails
   bootstrap-sass (~> 3.4.1)
   byebug
-  capybara (~> 3.12.0)
+  capybara
   cocoon
   coffee-rails (~> 4.2)
   database_cleaner

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -14,8 +14,8 @@ GIT
 
 GIT
   remote: https://github.com/BLSQ/orbf-rules_engine.git
-  revision: 86c1deae0a9cb2bd6a98dccb38b8ccca1b7f440c
-  branch: contracts-support
+  revision: ce5677ecff1f920c0969c7011572d329cacec31b
+  branch: master
   specs:
     orbf-rules_engine (0.1.0)
       activesupport

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -120,8 +120,7 @@ GEM
       rack-test (>= 0.6.3)
       regexp_parser (~> 1.2)
       xpath (~> 3.2)
-    childprocess (1.0.1)
-      rake (< 13.0)
+    childprocess (3.0.0)
     cocoon (1.2.12)
     coderay (1.1.2)
     coffee-rails (4.2.2)
@@ -444,9 +443,9 @@ GEM
     sawyer (0.8.1)
       addressable (>= 2.3.5, < 2.6)
       faraday (~> 0.8, < 1.0)
-    selenium-webdriver (3.142.3)
-      childprocess (>= 0.5, < 2.0)
-      rubyzip (~> 1.2, >= 1.2.2)
+    selenium-webdriver (3.142.7)
+      childprocess (>= 0.5, < 4.0)
+      rubyzip (>= 1.2.2)
     sentry-raven (2.7.4)
       faraday (>= 0.7.6, < 1.0)
     sexp_processor (4.11.0)
@@ -589,7 +588,7 @@ DEPENDENCIES
   ruby-prof
   rubyzip (~> 1.3.0)
   sassc-rails (~> 2.0.0)
-  selenium-webdriver (~> 3.142.3)
+  selenium-webdriver
   sentry-raven (~> 2.7.4)
   shoulda-matchers
   sidekiq (< 6)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -14,7 +14,7 @@ GIT
 
 GIT
   remote: https://github.com/BLSQ/orbf-rules_engine.git
-  revision: 1f12dffe1a18f494a593fa25aeb34b370631ba79
+  revision: 45c06080456fe83524e24dafe37dadc0f5159a69
   branch: contracts-support
   specs:
     orbf-rules_engine (0.1.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -14,7 +14,7 @@ GIT
 
 GIT
   remote: https://github.com/BLSQ/orbf-rules_engine.git
-  revision: 45c06080456fe83524e24dafe37dadc0f5159a69
+  revision: 86c1deae0a9cb2bd6a98dccb38b8ccca1b7f440c
   branch: contracts-support
   specs:
     orbf-rules_engine (0.1.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -14,7 +14,7 @@ GIT
 
 GIT
   remote: https://github.com/BLSQ/orbf-rules_engine.git
-  revision: 405605910e14602462b9914e7fee197a27d246bc
+  revision: 1f12dffe1a18f494a593fa25aeb34b370631ba79
   branch: contracts-support
   specs:
     orbf-rules_engine (0.1.0)
@@ -206,7 +206,7 @@ GEM
     httparty (0.16.3)
       mime-types (~> 3.0)
       multi_xml (>= 0.5.2)
-    i18n (1.8.2)
+    i18n (1.8.3)
       concurrent-ruby (~> 1.0)
     immigrant (0.3.6)
       activerecord (>= 3.0)
@@ -254,11 +254,11 @@ GEM
     method_source (0.9.2)
     mime-types (3.3.1)
       mime-types-data (~> 3.2015)
-    mime-types-data (3.2020.0425)
+    mime-types-data (3.2020.0512)
     mimemagic (0.3.3)
     mini_mime (1.0.1)
     mini_portile2 (2.4.0)
-    minitest (5.14.0)
+    minitest (5.14.1)
     msgpack (1.2.4)
     multi_json (1.13.1)
     multi_xml (0.6.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -8,13 +8,14 @@ GIT
 
 GIT
   remote: https://github.com/BLSQ/hesabu.git
-  revision: 3d8c033f081af8b5625d6621438eaf4c4230e97c
+  revision: 66b5e85447f2e1216e074d95e40945e5a2b852f5
   specs:
     hesabu (0.1.14)
 
 GIT
   remote: https://github.com/BLSQ/orbf-rules_engine.git
-  revision: 6a8b3979dca6044bd2c3aaa9aef68708137b3bb0
+  revision: 405605910e14602462b9914e7fee197a27d246bc
+  branch: contracts-support
   specs:
     orbf-rules_engine (0.1.0)
       activesupport
@@ -611,4 +612,4 @@ RUBY VERSION
    ruby 2.5.1p57
 
 BUNDLED WITH
-   2.0.2
+   2.1.4

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -130,6 +130,20 @@ $(document).ready(function() {
     $(".shortened-rules-container").toggle();
     $(".full-rules-container").toggle();
   });
+
+  function toggleEntityGroupSections(target)  {
+    if (target.selectedOptions[0] && target.selectedOptions[0].value=="contract_program_based") {
+      $("#contract_program_based").show()
+      $("#group_based").hide();
+    } else {
+      $("#contract_program_based").hide()
+      $("#group_based").show();
+    }
+  }
+  $("#entity_group_kind").on("change", function(event){
+    toggleEntityGroupSections(event.target)
+  });
+  toggleEntityGroupSections($("#entity_group_kind")[0])
 });
 
 

--- a/app/controllers/setup/autocomplete_controller.rb
+++ b/app/controllers/setup/autocomplete_controller.rb
@@ -90,6 +90,17 @@ class Setup::AutocompleteController < PrivateController
     render_sol_items(results, params[:term])
   end
 
+  def programs
+    expires_in 5.minutes
+    render_sol_items(current_project.dhis2_connection.programs.list(filter:"registration:eq:false"), params[:term].presence )
+  end
+
+  def sql_views
+    expires_in 5.minutes
+    sql_views = current_project.dhis2_connection.get("sqlViews")["sql_views"].map {|s| OpenStruct.new(s)}
+    render_sol_items(sql_views, params[:term].presence )
+  end
+
   private
 
   def search_results(term, kind, limit: 20)

--- a/app/controllers/setup/invoices_controller.rb
+++ b/app/controllers/setup/invoices_controller.rb
@@ -131,7 +131,9 @@ class Setup::InvoicesController < PrivateController
 
     @org_unit_summaries = Invoicing::EntitySignalitic.new(
       @pyramid,
-      invoicing_request.entity
+      invoicing_request.entity,
+      @invoice_entity.fetch_and_solve.contract_service,
+      invoicing_request.period
     ).call
 
     add_contract_warning_if_non_contracted(invoicing_request, project)

--- a/app/controllers/setup/main_entity_groups_controller.rb
+++ b/app/controllers/setup/main_entity_groups_controller.rb
@@ -37,8 +37,11 @@ class Setup::MainEntityGroupsController < PrivateController
   def entity_group_params
     params.require(:entity_group).permit(
       :name,
+      :kind,
       :external_reference,
-      :limit_snaphot_to_active_regions
+      :limit_snaphot_to_active_regions,
+      :program_reference,
+      :all_event_sql_view_reference
     )
   end
 end

--- a/app/controllers/setup/main_entity_groups_controller.rb
+++ b/app/controllers/setup/main_entity_groups_controller.rb
@@ -41,7 +41,9 @@ class Setup::MainEntityGroupsController < PrivateController
       :external_reference,
       :limit_snaphot_to_active_regions,
       :program_reference,
-      :all_event_sql_view_reference
+      :all_event_sql_view_reference,
+      :group_synchronisation_enabled,
+      :contract_delay_in_months
     )
   end
 end

--- a/app/models/entity_group.rb
+++ b/app/models/entity_group.rb
@@ -3,9 +3,12 @@
 # Table name: entity_groups
 #
 #  id                              :bigint(8)        not null, primary key
+#  all_event_sql_view_reference    :string
 #  external_reference              :string
+#  kind                            :string           default("group_based")
 #  limit_snaphot_to_active_regions :boolean          default(FALSE), not null
 #  name                            :string
+#  program_reference               :string
 #  created_at                      :datetime         not null
 #  updated_at                      :datetime         not null
 #  project_id                      :integer
@@ -20,10 +23,32 @@
 #
 
 class EntityGroup < ApplicationRecord
+
+  class Kinds
+    GROUP_BASED = "group_based"
+    CONTRACT_PROGRAM_BASED = "contract_program_based"
+    OPTIONS = [
+      ["Group based", Kinds::GROUP_BASED],
+      ["Contract program based", Kinds::CONTRACT_PROGRAM_BASED]
+    ]
+  end
+
   include PaperTrailed
+
   belongs_to :project
-  validates :external_reference, presence: true
-  validates :name, presence: true
+  validates :external_reference, presence: true, if: :group_based?
+  validates :name, presence: true, if: :group_based?
+  validates :program_reference, presence: true, if:  :contract_program_based?
+  validates :all_event_sql_view_reference, presence: true, if:  :contract_program_based?
 
   delegate :program_id, to: :project
+
+  def group_based?
+    kind == Kinds::GROUP_BASED
+  end
+
+  def contract_program_based?
+    kind == Kinds::CONTRACT_PROGRAM_BASED
+  end
+
 end

--- a/app/models/entity_group.rb
+++ b/app/models/entity_group.rb
@@ -4,7 +4,9 @@
 #
 #  id                              :bigint(8)        not null, primary key
 #  all_event_sql_view_reference    :string
+#  contract_delay_in_months        :integer          default(1)
 #  external_reference              :string
+#  group_synchronisation_enabled   :boolean          default(FALSE), not null
 #  kind                            :string           default("group_based")
 #  limit_snaphot_to_active_regions :boolean          default(FALSE), not null
 #  name                            :string

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -74,10 +74,12 @@ class Project < ApplicationRecord
   }
 
   def contract_settings
-    {
-      program_id: "TwcqxaLn11C",
-      all_event_sql_view_id: "QNKOsX4EGEk"
-    }
+    if entity_group.contract_program_based?
+      {
+        program_id: entity_group.program_reference,
+        all_event_sql_view_id: entity_group.all_event_sql_view_reference
+      }
+    end
   end
 
   # see PaperTrailed meta

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -73,6 +73,13 @@ class Project < ApplicationRecord
     message: "%{value} is not a valid see #{ENGINE_VERSIONS.join(',')}"
   }
 
+  def contract_settings
+    {
+      program_id: "TwcqxaLn11C",
+      all_event_sql_view_id: "QNKOsX4EGEk"
+    }
+  end
+
   # see PaperTrailed meta
   def project_id
     id

--- a/app/services/invoicing/entity_signalitic.rb
+++ b/app/services/invoicing/entity_signalitic.rb
@@ -2,10 +2,10 @@
 
 module Invoicing
   class EntitySignalitic
-    def initialize(pyramid, org_unit_id)
+    def initialize(pyramid, org_unit_id, contract_service, period)
       @pyramid = pyramid
       @org_unit_id = org_unit_id
-      @org_unit = build_org_unit_with_facts
+      @org_unit = build_org_unit_with_facts(contract_service, period)
     end
 
     def call
@@ -47,11 +47,11 @@ module Invoicing
       pyramid.groups(org_unit.group_ext_ids)
     end
 
-    def build_org_unit_with_facts
+    def build_org_unit_with_facts(contract_service, period)
       raw_org_unit = pyramid.org_unit(org_unit_id)
       Orbf::RulesEngine::OrgUnitWithFacts.new(
         orgunit: raw_org_unit,
-        facts:   Orbf::RulesEngine::OrgunitFacts.new(raw_org_unit, pyramid).to_facts
+        facts:   Orbf::RulesEngine::OrgunitFacts.new(org_unit:raw_org_unit, pyramid: pyramid, contract_service:contract_service, invoicing_period: period).to_facts
       )
     end
   end

--- a/app/services/map_project_to_orbf_project.rb
+++ b/app/services/map_project_to_orbf_project.rb
@@ -19,7 +19,8 @@ class MapProjectToOrbfProject
       engine_version:                        @engine_version,
       default_category_combo_ext_id:         project.default_coc_reference,
       default_attribute_option_combo_ext_id: project.default_aoc_reference,
-      calendar:                              project.calendar
+      calendar:                              project.calendar,
+      contract_settings:                     project.contract_settings
     )
   end
 

--- a/app/views/setup/setup/_step_entities.html.erb
+++ b/app/views/setup/setup/_step_entities.html.erb
@@ -79,6 +79,17 @@
         </div>
         <div class="col-md-6" id="all_event_sql_view_reference_selection"></div>
     </div>
+    <div class="row">
+      <div class="col-md-6">
+        <%= f.input :group_synchronisation_enabled, label: "Synchronise the groups based on the contract for the 'current' invoice period",
+         hint: "Don't enable this until you have correctly setuped the groups and the contracts are validated. Specially if it's a migration from a 'group' based to a 'contract' based project." %>
+      </div>
+    </div>
+    <div class="row">
+      <div class="col-md-6">
+        <%= f.input :contract_delay_in_months, hint: "The 'current' invoice period is defined based on current date minus this delay in months. Note the groups will be used by dhis2 (think pivot table) and our other products that don't support contracts but not the hesabu engine." %>
+      </div>
+    </div>
 </div>
 <%= f.button :submit, class: "btn btn-success" %>
 <% end %>

--- a/app/views/setup/setup/_step_entities.html.erb
+++ b/app/views/setup/setup/_step_entities.html.erb
@@ -1,33 +1,86 @@
+<div id="entities_edit">
 <% if step.model%>
 <%= simple_form_for(step.model,  url: setup_project_main_entity_group_path(project), method: :post) do |f| %>
-<div class="row">
-    <div class="col-md-6">
-        <div class="form-group">
-            <label class="control-label">Target group</label>
 
-            <%= f.input_field :external_reference,
-                              id: "main_target_group_selector",
-                              class: "form-control sol-powered",
-                              data: {
-                                selected: "[#{step.model.external_reference}]",
-                                placeholder:"Lookup the main target group here...",
-                                selection:"main_target_group_selection",
-                                url:organisation_unit_group_setup_project_autocomplete_index_path(project, term:'')
-                              } %>
-
-
-
-
-
-        </div>
-    </div>
-    <div class="col-md-6" id="main_target_group_selection"></div>
+<div >
+   <div class="form-group">
+       <label for="kind">Choose how entities contracts are defined</label>
+       <%= f.select(:kind, EntityGroup::Kinds::OPTIONS , {  },
+                         class: "form-control") %>
+      <p class="help-block">
+      Either using organisation unit groups and dhis2 snapshots or use the a dhis2 program to store contract's informations.
+      <p>
+   </div>
 </div>
-<%= f.input :limit_snaphot_to_active_regions,
-            hint: "To limit memory usage and speed up invoicing, "\
-            "take only the level_2 and their children if at least one of the children belongs to target group. "\
-            "Eg : 40.000 organisation units but only 2 regions actually"\
-            " in the target groups and so only need 3000 of them." %>
+<div id="group_based">
+    <div class="row">
+        <div class="col-md-6">
+            <div class="form-group">
+                <label class="control-label">Target group</label>
+
+                <%= f.input_field :external_reference,
+                                id: "main_target_group_selector",
+                                class: "form-control sol-powered",
+                                data: {
+                                    selected: "[#{step.model.external_reference}]",
+                                    placeholder:"Lookup the main target group here...",
+                                    selection:"main_target_group_selection",
+                                    url:organisation_unit_group_setup_project_autocomplete_index_path(project, term:'')
+                                } %>
+
+            </div>
+        </div>
+        <div class="col-md-6" id="main_target_group_selection"></div>
+    </div>
+    <div >
+    <%= f.input :limit_snaphot_to_active_regions,
+                hint: "To limit memory usage and speed up invoicing, "\
+                "take only the level_2 and their children if at least one of the children belongs to target group. "\
+                "Eg : 40.000 organisation units but only 2 regions actually"\
+                " in the target groups and so only need 3000 of them." %>
+    </div>
+</div>
+<div id="contract_program_based">
+    <div class="row">
+        <div class="col-md-6">
+            <div class="form-group">
+                <label class="control-label">Contract program</label>
+
+                <%= f.input_field :program_reference,
+                                id: "program_reference_selector",
+                                class: "form-control sol-powered",
+                                data: {
+                                    selected: "[#{step.model.program_reference}]",
+                                    placeholder:"Lookup the contract program here...",
+                                    selection:"program_reference_selection",
+                                    url:programs_setup_project_autocomplete_index_path(project, term:'')
+                                } %>
+
+            </div>
+        </div>
+        <div class="col-md-6" id="program_reference_selection"></div>
+    </div>
+    <div class="row">
+        <div class="col-md-6">
+            <div class="form-group">
+                <label class="control-label">Contract SQL View</label>
+
+                <%= f.input_field :all_event_sql_view_reference,
+                                id: "all_event_sql_view_reference_selector",
+                                class: "form-control sol-powered",
+                                data: {
+                                    selected: "[#{step.model.all_event_sql_view_reference}]",
+                                    placeholder:"Lookup the dhis2 sql view to find events here...",
+                                    selection:"all_event_sql_view_reference_selection",
+                                    url:sql_views_setup_project_autocomplete_index_path(project, term:'')
+                                } %>
+
+            </div>
+        </div>
+        <div class="col-md-6" id="all_event_sql_view_reference_selection"></div>
+    </div>
+</div>
 <%= f.button :submit, class: "btn btn-success" %>
 <% end %>
 <% end %>
+</div>

--- a/app/workers/synchronise_groups_worker.rb
+++ b/app/workers/synchronise_groups_worker.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+
+class SynchroniseGroupsWorker
+  include Sidekiq::Worker
+  include Sidekiq::Throttled::Worker
+
+  sidekiq_options retry: 1
+
+  sidekiq_throttle(
+    concurrency: { limit: 1 },
+    key_suffix:  ->(project_anchor_id, _time = Time.now.utc) { project_anchor_id }
+  )
+
+  def perform(project_anchor_id, now = Time.now.utc)
+    project_anchor = ProjectAnchor.find(project_anchor_id)
+    project = project_anchor.latest_draft || project_anchor.projects.for_date(now)
+
+    return unless project.entity_group.program_reference.presence
+
+    unless project.entity_group.group_synchronisation_enabled
+      puts "SynchroniseGroupsWorker skipped : group_synchronisation_enabled is not enabled"
+      return
+    end
+
+    # project :
+    #   contract_delay_in_months int
+    #   group_synchronisation_enabled true
+
+    contract_service = Orbf::RulesEngine::ContractService.new(
+      program_id:            project.entity_group.program_reference,
+      all_event_sql_view_id: project.entity_group.all_event_sql_view_reference,
+      dhis2_connection:      project.dhis2_connection,
+      calendar:              project.calendar
+    )
+    quarterly_period = current_period(now, project)
+    contract_service.synchronise_groups(quarterly_period)
+  end
+
+  def current_period(now, project)
+    calendar = project.calendar
+    delay_in_months = project.entity_group.contract_delay_in_months
+    delayed_date = now - delay_in_months.months
+    date_in_project_calendar = calendar.from_iso(delayed_date.to_datetime)
+
+    monthly_period = Periods.from_dhis2_period(date_in_project_calendar.strftime("%Y%m"))
+    quarterly_period = monthly_period.to_quarter.to_dhis2
+    puts ["groups synchronisation WITH delayed_date:#{delayed_date}",
+          "date_in_project_calendar:#{date_in_project_calendar}",
+          "monthly_period:#{monthly_period}",
+          "quarterly_period:#{quarterly_period}"].join("\t")
+
+    quarterly_period
+  end
+end

--- a/app/workers/synchronise_groups_worker.rb
+++ b/app/workers/synchronise_groups_worker.rb
@@ -18,7 +18,7 @@ class SynchroniseGroupsWorker
     return unless project.entity_group.program_reference.presence
 
     unless project.entity_group.group_synchronisation_enabled
-      puts "SynchroniseGroupsWorker skipped : group_synchronisation_enabled is not enabled"
+      puts "SynchroniseGroupsWorker skipped : #{project.id} - #{project.name} group_synchronisation_enabled is not enabled"
       return
     end
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -98,6 +98,8 @@ Rails.application.routes.draw do
             get :data_elements_with_cocs
             get :indicators
             get :category_combos
+            get :programs
+            get :sql_views
           end
         end
       end

--- a/db/migrate/20200608065708_add_contract_settings_to_entity_groups.rb
+++ b/db/migrate/20200608065708_add_contract_settings_to_entity_groups.rb
@@ -1,0 +1,7 @@
+class AddContractSettingsToEntityGroups < ActiveRecord::Migration[5.2]
+  def change
+    add_column :entity_groups, :kind, :string,  default: "group_based"
+    add_column :entity_groups, :program_reference, :string
+    add_column :entity_groups, :all_event_sql_view_reference, :string
+  end
+end

--- a/db/migrate/20200624112533_add_group_synchronisation_to_entity_groups.rb
+++ b/db/migrate/20200624112533_add_group_synchronisation_to_entity_groups.rb
@@ -1,0 +1,6 @@
+class AddGroupSynchronisationToEntityGroups < ActiveRecord::Migration[5.2]
+  def change
+    add_column :entity_groups, :group_synchronisation_enabled, :boolean, default: false, null: false
+    add_column :entity_groups, :contract_delay_in_months, :integer, default: 1, null: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_06_08_065708) do
+ActiveRecord::Schema.define(version: 2020_06_24_112533) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_stat_statements"
@@ -127,6 +127,8 @@ ActiveRecord::Schema.define(version: 2020_06_08_065708) do
     t.string "kind", default: "group_based"
     t.string "program_reference"
     t.string "all_event_sql_view_reference"
+    t.boolean "group_synchronisation_enabled", default: false, null: false
+    t.integer "contract_delay_in_months", default: 1
     t.index ["project_id"], name: "index_entity_groups_on_project_id"
   end
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_03_04_135000) do
+ActiveRecord::Schema.define(version: 2020_06_08_065708) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_stat_statements"
@@ -124,6 +124,9 @@ ActiveRecord::Schema.define(version: 2020_03_04_135000) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.boolean "limit_snaphot_to_active_regions", default: false, null: false
+    t.string "kind", default: "group_based"
+    t.string "program_reference"
+    t.string "all_event_sql_view_reference"
     t.index ["project_id"], name: "index_entity_groups_on_project_id"
   end
 

--- a/lib/invoice_entity_to_json.rb
+++ b/lib/invoice_entity_to_json.rb
@@ -42,7 +42,7 @@ class InvoiceEntityToJson
         @invoice_entity.pyramid,
         @invoicing_request.entity,
         @invoice_entity.fetch_and_solve.contract_service,
-        invoicing_request.period
+        @invoicing_request.period
       ).to_h,
       warnings:          contracted?(@invoicing_request, @project) ? nil : non_contracted_orgunit_message(@project)
     }

--- a/lib/invoice_entity_to_json.rb
+++ b/lib/invoice_entity_to_json.rb
@@ -40,7 +40,9 @@ class InvoiceEntityToJson
       engine_version:    @invoicing_request.engine_version,
       organisation_unit: Invoicing::EntitySignalitic.new(
         @invoice_entity.pyramid,
-        @invoicing_request.entity
+        @invoicing_request.entity,
+        @invoice_entity.fetch_and_solve.contract_service,
+        invoicing_request.period
       ).to_h,
       warnings:          contracted?(@invoicing_request, @project) ? nil : non_contracted_orgunit_message(@project)
     }

--- a/lib/tasks/group_sync.rake
+++ b/lib/tasks/group_sync.rake
@@ -1,0 +1,8 @@
+namespace :contracts do
+    desc "group_sync"
+    task group_sync: :environment do
+      ProjectAnchor.find_each do |anchor|
+        SynchroniseGroupsWorker.perform_async(anchor.id)
+      end
+    end
+  end


### PR DESCRIPTION
*Contracts settings are now stored on EntityGroup*

![image](https://user-images.githubusercontent.com/371692/85662864-b3807780-b6b8-11ea-98f5-a97211642644.png)


to avoid collision with program_id as foreign key to the hesabu/program, renamed them with _reference

I have failing tests... need to investigate why


TODO : 

- [ ] merge the companion PR from the engine : https://github.com/BLSQ/orbf-rules_engine/pull/65 
- [ ] change the orbf rule engine branch

WHEN deploying: 
- [ ] run the db migrations
- [ ] add the rake task to heroku scheduler : rake contracts:group_sync

