### PR TITLE
Fix: DHIS users with spaces could not parallel publish

### DIFF
--- a/lib/parallel_dhis2.rb
+++ b/lib/parallel_dhis2.rb
@@ -122,7 +122,7 @@ class ParallelDhis2
     end
 
     def user
-      base_uri.user
+      CGI.unescape(base_uri.user)
     end
 
     def password
@@ -182,6 +182,20 @@ class ParallelDhis2
 
   def prepare_payload(payload)
     Dhis2::Case.deep_change(payload, :camelize).to_json
+  end
+
+  # Mostly here as a sanity check if the client starts misbehaving,
+  # will issue a single request and return the response, which will
+  # have `body` and `code` and `return_code`, which helps debugging.
+  def get(url = "/api/system/status")
+    url = File.join(@client.url, url)
+    request = Typhoeus::Request.new(url,
+                                    method: :get,
+                                    headers: @client.post_headers,
+                                    ssl_verifypeer: @client.ssl_verify_peer?,
+                                    userpwd: [@client.user, @client.password].join(":"))
+    request.run
+    request.response
   end
 
   def build_post_request(url, payload)

--- a/lib/parallel_dhis2.rb
+++ b/lib/parallel_dhis2.rb
@@ -190,10 +190,10 @@ class ParallelDhis2
   def get(url = "/api/system/status")
     url = File.join(@client.url, url)
     request = Typhoeus::Request.new(url,
-                                    method: :get,
-                                    headers: @client.post_headers,
+                                    method:         :get,
+                                    headers:        @client.post_headers,
                                     ssl_verifypeer: @client.ssl_verify_peer?,
-                                    userpwd: [@client.user, @client.password].join(":"))
+                                    userpwd:        [@client.user, @client.password].join(":"))
     request.run
     request.response
   end

--- a/spec/lib/parallel_dhis2_spec.rb
+++ b/spec/lib/parallel_dhis2_spec.rb
@@ -246,10 +246,18 @@ RSpec.describe ParallelDhis2 do
       expect(client.post_headers).to eq("Accept" => "json", "Content-Type" => "application/json")
     end
 
-    it "#user" do
-      client = described_class.new(dhis2_client)
-      expect(client.user).to eq("admin")
+    describe "#user" do
+      it "handles normal ones" do
+        client = described_class.new(dhis2_client)
+        expect(client.user).to eq("admin")
+      end
+
+      it "handles with html entities or spaces in it" do
+        client = described_class.new(dhis2_client(user: "Someone BLSQ"))
+        expect(client.user).to eq("Someone BLSQ")
+      end
     end
+
 
     describe "#password" do
       it "handles normal ones" do


### PR DESCRIPTION
The parallel publisher would interpret the user as "Name+Something" instead of "Name Something" so DHIS would return 401's.