### PR TITLE
Add throttle per worker

### DIFF
--- a/app/workers/invoice_for_project_anchor_worker.rb
+++ b/app/workers/invoice_for_project_anchor_worker.rb
@@ -11,8 +11,8 @@ class InvoiceForProjectAnchorWorker
   sidekiq_throttle(
     concurrency: { limit: ENV.fetch("SDKQ_MAX_CONCURRENT_INVOICE", 3).to_i },
     key_suffix:  ->(project_anchor_id, _year, _quarter, _selected_org_unit_ids = nil, _options = {}) {
-      process_id = $PROCESS_ID
-      [project_anchor_id, process_id].join("-")
+      per_process_id = ENV.fetch("HEROKU_DYNO_ID", $PROCESS_ID)
+      [project_anchor_id, per_process_id].join("-")
     }
   )
 

--- a/app/workers/invoice_for_project_anchor_worker.rb
+++ b/app/workers/invoice_for_project_anchor_worker.rb
@@ -10,7 +10,10 @@ class InvoiceForProjectAnchorWorker
 
   sidekiq_throttle(
     concurrency: { limit: ENV.fetch("SDKQ_MAX_CONCURRENT_INVOICE", 3).to_i },
-    key_suffix:  ->(project_anchor_id, _year, _quarter, _selected_org_unit_ids = nil, _options = {}) { project_anchor_id }
+    key_suffix:  ->(project_anchor_id, _year, _quarter, _selected_org_unit_ids = nil, _options = {}) {
+      process_id = $PROCESS_ID
+      [project_anchor_id, process_id].join("-")
+    }
   )
 
   def perform(project_anchor_id, year, quarter, selected_org_unit_ids = nil, options = {})


### PR DESCRIPTION
So instead of sharing the lock across dyno's this will mean that each
dyno can run SDKQ_MAX_CONCURRENT_INVOICE invoices per project anchor
on each dyno.