### PR TITLE
Add cal_days_in_month and year as a period fact

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -8,13 +8,13 @@ GIT
 
 GIT
   remote: https://github.com/BLSQ/hesabu.git
-  revision: 66b5e85447f2e1216e074d95e40945e5a2b852f5
+  revision: c46f76ed53b7b71909b59d4933efb39d20e6c68b
   specs:
     hesabu (0.1.14)
 
 GIT
   remote: https://github.com/BLSQ/orbf-rules_engine.git
-  revision: abdd49aeb77904be79d4aec03a978db58d613d6c
+  revision: 7b5b1984899867d751e344e18dc7cc7a62739343
   branch: master
   specs:
     orbf-rules_engine (0.1.0)

--- a/app/models/rule_types/activity_rule_type.rb
+++ b/app/models/rule_types/activity_rule_type.rb
@@ -20,6 +20,7 @@ module RuleTypes
       var_names.push(*formulas.map(&:code))
       var_names.push(*Analytics::Locations::LevelScope.new.facts(package))
       var_names.push(*available_variables_for_values.map { |code| "%{#{code}}" })
+      var_names.push("year")
       var_names.push("quarter_of_year")
       var_names.push("month_of_year")
       var_names.push("month_of_quarter")

--- a/app/models/rule_types/base_rule_type.rb
+++ b/app/models/rule_types/base_rule_type.rb
@@ -20,6 +20,8 @@ module RuleTypes
 
     def to_fake_facts(states)
       facts = states.map { |state| [state.code.to_sym, "10"] }.to_h
+
+      facts[:year] = 2016
       facts[:month_of_year] = 6
       facts[:quarter_of_year] = 2
       facts[:month_of_quarter] = 3

--- a/app/views/setup/rules/_cheat_sheet_expression.html.erb
+++ b/app/views/setup/rules/_cheat_sheet_expression.html.erb
@@ -121,7 +121,11 @@ EXPL
     "SQRT" => [
       "SQRT(number)",
       "Returns a positive square root. If the the number is negative this will fails. "
-    ]
+    ],
+    "CAL_DAYS_IN_MONTH" => [
+      "CAL_DAYS_IN_MONTH(year, month_of_year)",
+      "Returns the number days in gregorian calendar for that month. month_of_year is from 1 to 12, year should be > 1900"
+    ],
   }
 %>
 <dl>

--- a/spec/lib/rules_engine_spec.rb
+++ b/spec/lib/rules_engine_spec.rb
@@ -47,6 +47,13 @@ RSpec.describe "Rules Engine" do
         expect(solution["formula"]).to eq(4.0)
       end
 
+      it ".cal_days_in_month (#{name})" do
+        solution = calculator.solve(
+          "formula" => "cal_days_in_month(2020,2)",
+        )
+        expect(solution["formula"]).to eq(29)
+      end
+
     end
   end
 end

--- a/spec/models/rules_spec.rb
+++ b/spec/models/rules_spec.rb
@@ -306,6 +306,7 @@ RSpec.describe Rule, kind: :model do
        claimed_level_5
        claimed_level_5_quarterly
        difference_percentage
+       year
        month_of_quarter
        month_of_year
        quantity
@@ -688,6 +689,7 @@ RSpec.describe Rule, kind: :model do
        month_of_quarter
        month_of_year
        quarter_of_year
+       year
       ]
       expect(activity_rule.available_variables).to match_array(expected)
     end


### PR DESCRIPTION
companion PRs
 - https://github.com/BLSQ/go-hesabu/pull/20
 - https://github.com/BLSQ/hesabu/pull/13
 - https://github.com/BLSQ/orbf-rules_engine/pull/69

**add support to calculate the number of days of a month**

you have now 
- access to the `year` of the invoice as period fact and 
- a function `cal_days_in_month(year, month_of_year)`

**limitations:** won't work on Ethiopian calendar...


![image](https://user-images.githubusercontent.com/371692/93581210-1d9b7680-f9a1-11ea-9db7-2db02638c757.png)

![image](https://user-images.githubusercontent.com/371692/93580095-9d284600-f99f-11ea-9708-5ba96470d5b0.png)


