### PR TITLE
Fix responses without dataset complete

### DIFF
--- a/lib/parallel_dhis2.rb
+++ b/lib/parallel_dhis2.rb
@@ -107,7 +107,7 @@ class ParallelDhis2
 
     def data_set_complete
       # Practically always false
-      rolled_up["data_set_complete"].compact.uniq.first
+      (rolled_up["data_set_complete"] || []).compact.uniq.first
     end
   end
 

--- a/script/setup
+++ b/script/setup
@@ -13,7 +13,7 @@ if [ -f "config/database.yml" ] ; then
     true
 else
     echo "==> Generating config/database.yml"
-    cp config/database-template.yml.example config/database.yml
+    cp config/database-template.yml config/database.yml
 fi
 
 if [ -f "config/application.yml" ] ; then

--- a/spec/lib/parallel_dhis2_spec.rb
+++ b/spec/lib/parallel_dhis2_spec.rb
@@ -159,6 +159,18 @@ RSpec.describe ParallelDhis2 do
         it(:import_options) { expect(rolled_up["import_options"].count).to eq(5) }
         it(:data_set_complete) { expect(rolled_up["data_set_complete"]).to eq(false) }
       end
+
+      describe "without data_set_complete" do
+        subject(:failed_response_without_dataset_complete) {
+          response = fake_response(status:       "ERROR",
+                        description:  "The import process failed: Failed to update object",
+                        import_count: { "deleted": 0, "ignored": 0, "updated": 0, "imported": 0 })
+          response.delete("data_set_complete")
+          response
+        }
+        subject(:rolled_up) { described_class.new([failed_response_without_dataset_complete]).call }
+        it(:data_set_complete) { expect(rolled_up["data_set_complete"]).to be_nil }
+      end
     end
 
     describe "#status" do


### PR DESCRIPTION
I don't know why, but sometimes the error popups:

      https://sentry.io/organizations/bluesquareorg/issues/1850775543/?project=213257&query=is%3Aunresolved

This will make it so that it doesn't error, and maybe shows what is the root cause of the error.

It does have responses (otherwise we would get an empty hash back in the hash) so it needs to be having responses returned that don't carry the `data_set_complete`, so maybe it's a one-off DHIS thing. It doesn't happen always, but on a set of 500-ish invoices, it's bound to happen on one of them.
