### PR TITLE
Also support last_xx_months_values

### DIFF
--- a/app/services/rules/values_mocker.rb
+++ b/app/services/rules/values_mocker.rb
@@ -20,7 +20,7 @@ module Rules
       if variable_name.end_with?("_current_quarter_values")
         length = 3
       else
-        matched_window = variable_name.match(/.last_(?<length>\d)_(month|quarter)s_window_values/)
+        matched_window = variable_name.match(/.last_(?<length>\d+)_(month|quarter)s_window_values/)
         length = Integer(matched_window[:length]) if matched_window
       end
       (1..length).map(&:to_s).join(" , ")

--- a/spec/services/rules/solver_spec.rb
+++ b/spec/services/rules/solver_spec.rb
@@ -37,6 +37,13 @@ RSpec.describe Rules::ValuesMocker, type: :services do
            )).to eq "SUM(4,6) /SUM(1 , 2 , 3 , 4 , 5 , 6 , 7) * 100.0"
   end
 
+  it "substitute %{last_xx_months_window_values} (double digits) with a correct size equations" do
+    expect(Rules::ValuesMocker.mock_values(
+             "SUM(4,6) /SUM(%{demo_last_15_months_window_values}) * 100.0",
+             ["demo_last_15_months_window_values"]
+           )).to eq "SUM(4,6) /SUM(1 , 2 , 3 , 4 , 5 , 6 , 7 , 8 , 9 , 10 , 11 , 12 , 13 , 14 , 15) * 100.0"
+  end
+
   it "substitute %{_current_quarter_values} with a correct size equations" do
     expect(Rules::ValuesMocker.mock_values(
              "SUM(4,6) / SUM(%{demo_current_quarter_values}) * 100.0",


### PR DESCRIPTION
The regex only took the last one, so it supplied an incorrect number of values for the array, thus creating an error.
