### PR TITLE
Jsonapi fetch project fully

### DIFF
--- a/app/controllers/api/v2/projects_controller.rb
+++ b/app/controllers/api/v2/projects_controller.rb
@@ -6,7 +6,7 @@ module Api
       def show
         options = {}
         project = nil
-        if params[:fields] == ":all"
+        if params[:profile] == "full"
           options[:include] = default_relationships
           project = current_project_anchor.projects.fully_loaded.find(current_project_anchor.project.id)
         else

--- a/app/controllers/api/v2/projects_controller.rb
+++ b/app/controllers/api/v2/projects_controller.rb
@@ -4,10 +4,45 @@ module Api
   module V2
     class ProjectsController < BaseController
       def show
-        render json: serializer_class.new(current_project_anchor).serialized_json
+        options = {}
+        project = nil
+        if params[:fields] == ":all"
+          options[:include] = default_relationships
+          project = current_project_anchor.projects.fully_loaded.find(current_project_anchor.project.id)
+        else
+          project = current_project_anchor.project
+        end
+        render json: serializer_class.new(project, options).serialized_json
       end
 
       private
+
+      def default_relationships
+        %i[
+          compounds
+          sets
+          sets.topics
+          sets.org_unit_groups
+          sets.org_unit_group_sets
+          sets.topics.input_mappings
+          compounds.formulas
+          compounds.sets
+          compounds.formulas.formula_mappings
+        ] + default_sets_relationships
+
+      end
+
+      def default_sets_relationships
+        %w[topic set zone_topic zone multi_entities].flat_map do |scope|
+          [
+            "sets",
+            "sets.#{scope}_decision_tables",
+            "sets.#{scope}_formulas",
+            "sets.#{scope}_formulas.formula_mappings",
+            "sets.#{scope}_formulas.formula_mappings.external_ref"
+          ].map(&:to_sym)
+        end
+      end
 
       def serializer_class
         ::V2::ProjectAnchorSerializer

--- a/app/serializers/v2/package_serializer.rb
+++ b/app/serializers/v2/package_serializer.rb
@@ -33,7 +33,7 @@ class V2::PackageSerializer < V2::BaseSerializer
     end
   end
 
-  has_many :inputs, serializer: V2::StateSerializer do |package|
+  has_many :inputs, serializer: V2::StateSerializer, record_type: :input do |package|
     package.states
   end
 

--- a/app/serializers/v2/project_anchor_serializer.rb
+++ b/app/serializers/v2/project_anchor_serializer.rb
@@ -1,11 +1,11 @@
 # frozen_string_literal: true
 
 class V2::ProjectAnchorSerializer < V2::BaseSerializer
-  attribute :dhis2_url do |project_anchor|
-    project_anchor.project&.dhis2_url
+  attribute :dhis2_url do |project|
+    project&.dhis2_url
   end
-  attribute :periods do |project_anchor|
-    project = project_anchor.project
+  attribute :periods do |project|
+
     if project
       start_year = 2016
       end_year = project.calendar.from_iso(DateTime.now).year + 1
@@ -16,22 +16,30 @@ class V2::ProjectAnchorSerializer < V2::BaseSerializer
   end
   attribute :created_at
   attribute :updated_at
-  attribute :cycle do |project_anchor|
-    project_anchor.project&.cycle
+  attribute :cycle do |project|
+    project&.cycle
   end
-  attribute :name do |project_anchor|
-    project_anchor.project&.name
-  end
-
-  attribute :code do |project_anchor|
-    project_anchor.program&.code
+  attribute :name do |project|
+    project&.name
   end
 
-  has_many :inputs do |project_anchor|
-    project_anchor.project&.states
+  attribute :code do |project|
+    project&.project_anchor&.program&.code
   end
 
-  has_many :simulations do |project_anchor|
-    project_anchor.invoicing_simulation_jobs
+  has_many :inputs do |project|
+    project&.states
+  end
+
+  has_many :sets, serializer: V2::PackageSerializer, record_type: "set"  do |project|
+    project&.packages
+  end
+
+  has_many :compounds, serializer: V2::PaymentRuleSerializer, record_type: "compound"  do |project|
+    project.project_anchor.project&.payment_rules
+  end
+
+  has_many :simulations do |project|
+    project.project_anchor.invoicing_simulation_jobs
   end
 end

--- a/spec/controllers/api/v2/projects_controller_spec.rb
+++ b/spec/controllers/api/v2/projects_controller_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe Api::V2::ProjectsController, type: :controller do
       get(:show, params: {})
       resp = JSON.parse(response.body)
 
-      expect(resp["data"]["id"]).to eq(project.project_anchor.id.to_s)
+      expect(resp["data"]["id"]).to eq(project.id.to_s)
     end
 
     it "returns periods" do

--- a/spec/controllers/api/v2/projects_controller_spec.rb
+++ b/spec/controllers/api/v2/projects_controller_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "rails_helper"
 
 RSpec.describe Api::V2::ProjectsController, type: :controller do
@@ -7,15 +9,19 @@ RSpec.describe Api::V2::ProjectsController, type: :controller do
   let(:token) { "123456789" }
   let!(:project) do
     project = full_project
-    project.project_anchor.update_attributes(token: token)
+    project.project_anchor.update(token: token)
     project.save!
     project
   end
 
   describe "#show" do
-    it "returns project" do
+    def with_correct_headers
       request.headers["Accept"] = "application/vnd.api+json;version=2"
       request.headers["X-Token"] = project.project_anchor.token
+    end
+
+    it "returns project" do
+      with_correct_headers
       get(:show, params: {})
       resp = JSON.parse(response.body)
 
@@ -23,12 +29,19 @@ RSpec.describe Api::V2::ProjectsController, type: :controller do
     end
 
     it "returns periods" do
-      request.headers["Accept"] = "application/vnd.api+json;version=2"
-      request.headers["X-Token"] = project.project_anchor.token
+      with_correct_headers
       get(:show, params: {})
       resp = JSON.parse(response.body)
 
       expect(resp["data"]["attributes"]["periods"]).to include("2016Q1")
+    end
+
+    it "returns project fully" do
+      with_correct_headers
+      get(:show, params: { profile: "full" })
+      resp = JSON.parse(response.body)
+
+      expect(resp["data"]["id"]).to eq(project.id.to_s)
     end
   end
 end


### PR DESCRIPTION
To ease investigations/lookups, I've added a way to load the project.

According to json api spec, `include` is supposed to be a list of relationships, I've introduced a param called `profile`.
That list of relationship is really really long and didn't wanted to have the client to known about all the ramifications
I prefered to use `?profile=full`

example usage from taskr

```js
const api = await dhis2.api();
const hesabu = await api.get("dataStore/hesabu/hesabu");
const projectJson = await fetch(hesabu.url + "/api/project?profile=full", {
  credentials: "omit",
  headers: {
    "X-Token": hesabu.token,
    Accept: "application/vnd.api+json;version=2"
  }
}).then(r => r.json());

const project = JSONApi.deserialize(projectJson);
JSON.stringify(project, (key, value) => {
  return JSON.parse(JSON.stringify(value));
});
return project;
```
