### PR TITLE
Wip a first version for create

### DIFF
--- a/app/controllers/api/v2/base_controller.rb
+++ b/app/controllers/api/v2/base_controller.rb
@@ -22,7 +22,7 @@ module Api
       end
 
       rescue_from ActiveRecord::RecordInvalid do |exception|
-        error = { status: "409", message: exception.message, details: exception.record.errors.messages}
+        error = { status: "400", message: exception.message, details: exception.record.errors.messages}
         render status: :bad_request, json: { errors: [error] }
       end
 

--- a/app/controllers/api/v2/base_controller.rb
+++ b/app/controllers/api/v2/base_controller.rb
@@ -21,6 +21,11 @@ module Api
         render status: :unauthorized, json: { errors: [error] }
       end
 
+      rescue_from ActiveRecord::RecordInvalid do |exception|
+        error = { status: "409", message: exception.message, details: exception.record.errors.messages}
+        render status: :bad_request, json: { errors: [error] }
+      end
+
       def options
         render json: {}
       end

--- a/app/controllers/api/v2/base_controller.rb
+++ b/app/controllers/api/v2/base_controller.rb
@@ -22,7 +22,11 @@ module Api
       end
 
       rescue_from ActiveRecord::RecordInvalid do |exception|
-        error = { status: "400", message: exception.message, details: exception.record.errors.messages}
+        error = {
+          status:  "400",
+          message: exception.message,
+          details: exception.record.errors.messages
+        }
         render status: :bad_request, json: { errors: [error] }
       end
 

--- a/app/controllers/api/v2/base_controller.rb
+++ b/app/controllers/api/v2/base_controller.rb
@@ -36,6 +36,13 @@ module Api
 
       private
 
+      def check_whodunnit!
+        dhis2_user_id = request.headers["X-Dhis2UserId"] || params[:dhis2UserId]
+        raise UnauthorizedAccess unless dhis2_user_id
+
+        PaperTrail.request.whodunnit = dhis2_user_id
+      end
+
       def check_token!
         token = request.headers["X-Token"] || params[:token]
         if token

--- a/app/controllers/api/v2/input_mappings_controller.rb
+++ b/app/controllers/api/v2/input_mappings_controller.rb
@@ -2,6 +2,8 @@
 
 module Api::V2
   class InputMappingsController < BaseController
+    before_action :check_whodunnit!, only: %i[create update delete]
+
     def create
       activity = current_activity
       state_code = input_params[:attributes][:code]

--- a/app/controllers/api/v2/input_mappings_controller.rb
+++ b/app/controllers/api/v2/input_mappings_controller.rb
@@ -14,7 +14,7 @@ module Api::V2
       activity_state = activity.activity_states.create!(input_attributes.merge(state_id: state.id))
       # make stable id visible
       activity_state.reload
-      render json: serializer_class.new(activity_state, include: default_relationships).serialized_json
+      render_activity_state(activity_state)
     end
 
     def index
@@ -33,10 +33,19 @@ module Api::V2
               end
       activity_state.update!(input_attributes.merge(state_id: state.id))
 
-      render json: serializer_class.new(activity_state, include: default_relationships).serialized_json
+      render_activity_state(activity_state)
     end
 
     private
+
+    def render_activity_state(activity_state)
+      render(
+        json: serializer_class.new(
+          activity_state,
+          include: default_relationships
+        ).serialized_json
+      )
+    end
 
     def default_relationships
       %i[input external_ref]

--- a/app/controllers/api/v2/input_mappings_controller.rb
+++ b/app/controllers/api/v2/input_mappings_controller.rb
@@ -1,0 +1,67 @@
+# frozen_string_literal: true
+
+module Api::V2
+  class InputMappingsController < BaseController
+    def create
+      activity = current_activity
+      state_code = input_params[:attributes][:code]
+      state = if state_code
+                # ease client work allowing to pass the state code
+                activity.project.state(state_code)
+              else
+                # find by relationships ?
+              end
+      activity_state = activity.activity_states.create!(input_attributes.merge(state_id: state.id))
+      # make stable id visible
+      activity_state.reload
+      render json: serializer_class.new(activity_state, include: default_relationships).serialized_json
+    end
+
+    def index
+      inputs = current_activity.activity_states
+      render json: serializer_class.new(inputs, include: default_relationships).serialized_json
+    end
+
+    private
+
+    def default_relationships
+      %i[input external_ref]
+    end
+
+    def current_project
+      current_project_anchor.project
+    end
+
+    def current_activity
+      current_project.activities.find(params[:topic_id])
+    end
+
+    def serializer_class
+      ::V2::ActivityStateSerializer
+    end
+
+    def input_params
+      params.require(:data)
+            .permit(:type,
+                    attributes: %i[
+                      code
+                      formula
+                      name
+                      origin
+                      kind
+                      externalReference
+                    ])
+    end
+
+    def input_attributes
+      att = input_params[:attributes]
+      {
+        formula:            att[:formula].presence,
+        name:               att[:name].presence,
+        origin:             att[:origin].presence,
+        kind:               att[:kind].presence,
+        external_reference: att[:externalReference].presence
+      }
+    end
+  end
+end

--- a/app/controllers/api/v2/input_mappings_controller.rb
+++ b/app/controllers/api/v2/input_mappings_controller.rb
@@ -22,6 +22,20 @@ module Api::V2
       render json: serializer_class.new(inputs, include: default_relationships).serialized_json
     end
 
+    def update
+      activity_state = current_activity.activity_states.find(params[:id])
+      state_code = input_params[:attributes][:code]
+      state = if state_code
+                # ease client work allowing to pass the state code
+                activity_state.activity.project.state(state_code)
+              else
+                activity_state.state
+              end
+      activity_state.update!(input_attributes.merge(state_id: state.id))
+
+      render json: serializer_class.new(activity_state, include: default_relationships).serialized_json
+    end
+
     private
 
     def default_relationships

--- a/app/controllers/api/v2/topics_controller.rb
+++ b/app/controllers/api/v2/topics_controller.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+module Api::V2
+  class TopicsController < BaseController
+    def create
+
+      item = current_project_anchor.project.activities.create!(topic_attributes)
+
+      item.reload
+      render json: serializer_class.new(item).serialized_json
+    end
+
+    private
+
+    def serializer_class
+      ::V2::ActivitySerializer
+    end
+
+    def topic_params
+      params.require(:data)
+            .permit(:type,
+                    attributes: %i[
+                      code
+                      name
+                      shortName
+                    ])
+    end
+
+    def topic_attributes
+      {
+        name:       topic_params[:attributes][:name],
+        short_name: topic_params[:attributes][:shortName],
+        code:       topic_params[:attributes][:code]
+      }
+    end
+  end
+end

--- a/app/controllers/api/v2/topics_controller.rb
+++ b/app/controllers/api/v2/topics_controller.rb
@@ -2,6 +2,8 @@
 
 module Api::V2
   class TopicsController < BaseController
+    before_action :check_whodunnit!, only: %i[create update delete]
+
     def create
       topic = current_project.activities.create!(topic_attributes)
       # make stable id visible

--- a/app/controllers/api/v2/topics_controller.rb
+++ b/app/controllers/api/v2/topics_controller.rb
@@ -9,6 +9,14 @@ module Api::V2
       render json: serializer_class.new(topic).serialized_json
     end
 
+
+    def update
+      topic = current_project.activities.find(params[:id])
+      topic.update_attributes!(topic_attributes)
+
+      render json: serializer_class.new(topic).serialized_json
+    end
+
     def index
       topics = current_project.activities
       render json: serializer_class.new(topics).serialized_json

--- a/app/controllers/api/v2/topics_controller.rb
+++ b/app/controllers/api/v2/topics_controller.rb
@@ -9,10 +9,9 @@ module Api::V2
       render json: serializer_class.new(topic).serialized_json
     end
 
-
     def update
       topic = current_project.activities.find(params[:id])
-      topic.update_attributes!(topic_attributes)
+      topic.update!(topic_attributes)
 
       render json: serializer_class.new(topic).serialized_json
     end

--- a/app/controllers/api/v2/topics_controller.rb
+++ b/app/controllers/api/v2/topics_controller.rb
@@ -3,14 +3,22 @@
 module Api::V2
   class TopicsController < BaseController
     def create
+      topic = current_project.activities.create!(topic_attributes)
+      # make stable id visible
+      topic.reload
+      render json: serializer_class.new(topic).serialized_json
+    end
 
-      item = current_project_anchor.project.activities.create!(topic_attributes)
-
-      item.reload
-      render json: serializer_class.new(item).serialized_json
+    def index
+      topics = current_project.activities
+      render json: serializer_class.new(topics).serialized_json
     end
 
     private
+
+    def current_project
+      current_project_anchor.project
+    end
 
     def serializer_class
       ::V2::ActivitySerializer
@@ -27,10 +35,11 @@ module Api::V2
     end
 
     def topic_attributes
+      att = topic_params[:attributes]
       {
-        name:       topic_params[:attributes][:name],
-        short_name: topic_params[:attributes][:shortName],
-        code:       topic_params[:attributes][:code]
+        name:       att[:name],
+        short_name: att[:shortName],
+        code:       att[:code]
       }
     end
   end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -45,6 +45,8 @@ Rails.application.routes.draw do
       resources :sets, only: %i[index show]
       resources :compounds, only: %i[index show]
       resources :simulations, only: %i[index show]
+      resources :topics, only: %i[create update]
+
       get :simulation, to: "simulations#query_based_show"
 
       match "*path",

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -39,13 +39,15 @@ Rails.application.routes.draw do
             constraints: { method: "OPTIONS" },
             via:         [:options]
     end
-    scope module: :v2, constraints: ApiConstraints.new(version: 2) do
+    scope module: :v2 , constraints: ApiConstraints.new(version: 2)do
       resource :project, only: [:show]
       resources :org_units, only: [:index]
       resources :sets, only: %i[index show]
       resources :compounds, only: %i[index show]
       resources :simulations, only: %i[index show]
-      resources :topics, only: %i[create update]
+      resources :topics, only: %i[index create update] do
+        resources :input_mappings, only: %i[index create update]
+      end
 
       get :simulation, to: "simulations#query_based_show"
 

--- a/spec/controllers/api/v2/input_mappings_controller_spec.rb
+++ b/spec/controllers/api/v2/input_mappings_controller_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe Api::V2::InputMappingsController, type: :controller do
         }
       }
     }
-    it "create a input" do
+    it "create a input mapping" do
       post(:create, params: payload)
 
       resp = JSON.parse(response.body)
@@ -49,7 +49,7 @@ RSpec.describe Api::V2::InputMappingsController, type: :controller do
       expect(attributes["formula"]).to be_nil
     end
 
-    it "create a topic handles validation errors" do
+    it "create a input mapping handles validation errors" do
       post(:create,
            params: payload)
 

--- a/spec/controllers/api/v2/input_mappings_controller_spec.rb
+++ b/spec/controllers/api/v2/input_mappings_controller_spec.rb
@@ -13,6 +13,7 @@ RSpec.describe Api::V2::InputMappingsController, type: :controller do
   def authenticated
     request.headers["Accept"] = "application/vnd.api+json;version=2"
     request.headers["X-Token"] = project.project_anchor.token
+    request.headers["X-Dhis2UserId"] = "aze123sdf"
   end
 
   describe "#create" do

--- a/spec/controllers/api/v2/input_mappings_controller_spec.rb
+++ b/spec/controllers/api/v2/input_mappings_controller_spec.rb
@@ -1,0 +1,68 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Api::V2::InputMappingsController, type: :controller do
+  let(:token) { "123456789" }
+  let(:program) { create :program }
+  let(:project_anchor) { create :project_anchor, token: token, program: program }
+  let(:project) { create :project, project_anchor: project_anchor }
+  let(:activity) { create :activity, project: project, name: "Topic 1", code: "topic_01" }
+  let(:state) { create :state, project: project, name: "declared" }
+
+  describe "#create" do
+    before do
+      request.headers["Accept"] = "application/vnd.api+json;version=2"
+      request.headers["X-Token"] = project.project_anchor.token
+    end
+    let(:payload) {
+      {
+        topic_id: activity.id,
+        data:     {
+          attributes: {
+            code:              state.code,
+            formula:           nil,
+            name:              "sample",
+            origin:            "dataValueSets",
+            kind:              "data_element",
+            externalReference: "dhis2id"
+          }
+        }
+      }
+    }
+    it "create a input" do
+      post(:create, params: payload)
+
+      resp = JSON.parse(response.body)
+
+      expect(resp["data"]["type"]).to eq("inputMapping")
+
+      attributes = resp["data"]["attributes"]
+
+      expect(attributes["name"]).to eq("sample")
+      expect(attributes["origin"]).to eq("dataValueSets")
+      expect(attributes["kind"]).to eq("data_element")
+
+      expect(attributes["externalReference"]).to eq("dhis2id")
+
+      expect(attributes["stableId"]).not_to be_nil
+      expect(attributes["formula"]).to be_nil
+    end
+
+    it "create a topic handles validation errors" do
+      post(:create,
+           params: payload)
+
+      post(:create,
+           params: payload)
+      resp = JSON.parse(response.body)
+      expect(resp).to eq(
+        "errors" => [
+          { "details" => { "state_id"=>["has already been taken"] },
+            "message" => "Validation failed: State has already been taken",
+            "status"  => "400" }
+        ]
+      )
+    end
+  end
+end

--- a/spec/controllers/api/v2/topics_controller_spec.rb
+++ b/spec/controllers/api/v2/topics_controller_spec.rb
@@ -7,10 +7,15 @@ RSpec.describe Api::V2::TopicsController, type: :controller do
   let(:program) { create :program }
   let(:project_anchor) { create :project_anchor, token: token, program: program }
   let(:project) { create :project, project_anchor: project_anchor }
+
+  def authenticated
+    request.headers["Accept"] = "application/vnd.api+json;version=2"
+    request.headers["X-Token"] = project.project_anchor.token
+  end
+
   describe "#create" do
     before do
-      request.headers["Accept"] = "application/vnd.api+json;version=2"
-      request.headers["X-Token"] = project.project_anchor.token
+      authenticated
     end
     let(:payload) {
       { data: {
@@ -47,6 +52,59 @@ RSpec.describe Api::V2::TopicsController, type: :controller do
                              "message" => "Validation failed: Code has already been taken",
                              "details" => { "code" => ["has already been taken"] } }
                          ])
+    end
+  end
+
+  describe "#create" do
+    before do
+      authenticated
+    end
+    let(:payload) {
+      {
+        id:   activity.id,
+        data: {
+          attributes: {
+            name:      "Topic very long name new",
+            shortName: "Topic new",
+            code:      "med_01"
+          }
+        }
+      }
+    }
+    let(:activity) {
+      project.activities.create!(name: "demo")
+    }
+
+    it "update a topic" do
+      activity.reload
+
+      put(:update, params: payload)
+
+      resp = JSON.parse(response.body)
+
+      expect(resp["data"]["type"]).to eq("topic")
+
+      attributes = resp["data"]["attributes"]
+
+      expect(attributes["code"]).to eq("med_01")
+      expect(attributes["name"]).to eq("Topic very long name new")
+      expect(attributes["shortName"]).to eq("Topic new")
+
+      expect(attributes["stableId"]).to eq(activity.stable_id)
+    end
+
+    it "update a topic handles validation errors" do
+      payload[:data][:attributes][:shortName] = "super very veryveryveryveryveryveryveryveryveryveryveryveryvery long"
+      put(:update, params: payload)
+
+      resp = JSON.parse(response.body)
+      expect(resp).to eq(
+        "errors" => [
+          { "details" => { "short_name"=>["is too long (maximum is 40 characters)"] },
+            "message" => "Validation failed: Short name is too long (maximum is 40 characters)",
+            "status"  => "400" }
+        ]
+      )
     end
   end
 end

--- a/spec/controllers/api/v2/topics_controller_spec.rb
+++ b/spec/controllers/api/v2/topics_controller_spec.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Api::V2::TopicsController, type: :controller do
+  let(:token) { "123456789" }
+  let(:program) { create :program }
+  let(:project_anchor) { create :project_anchor, token: token, program: program }
+  let(:project) { create :project, project_anchor: project_anchor }
+  describe "#create" do
+    before do
+      request.headers["Accept"] = "application/vnd.api+json;version=2"
+      request.headers["X-Token"] = project.project_anchor.token
+    end
+    let(:payload) {
+      { data: {
+        attributes: {
+          name:      "Topic very long name",
+          shortName: "Topic"
+        }
+      } }
+    }
+    it "create a topic" do
+      post(:create, params: payload)
+
+      resp = JSON.parse(response.body)
+
+      expect(resp["data"]["type"]).to eq("topic")
+
+      attributes = resp["data"]["attributes"]
+      expect(attributes["code"]).to eq("topic_very_long_name")
+      expect(attributes["name"]).to eq("Topic very long name")
+      expect(attributes["shortName"]).to eq("Topic")
+
+      expect(attributes["stableId"]).not_to be_nil
+    end
+
+    it "create a topic handles validation errors" do
+      post(:create,
+           params: payload)
+
+      post(:create,
+           params: payload)
+      resp = JSON.parse(response.body)
+      expect(resp).to eq("errors" => [
+                           { "status"  => "409",
+                             "message" => "Validation failed: Code has already been taken",
+                             "details" => { "code" => ["has already been taken"] } }
+                         ])
+    end
+  end
+end

--- a/spec/controllers/api/v2/topics_controller_spec.rb
+++ b/spec/controllers/api/v2/topics_controller_spec.rb
@@ -11,6 +11,7 @@ RSpec.describe Api::V2::TopicsController, type: :controller do
   def authenticated
     request.headers["Accept"] = "application/vnd.api+json;version=2"
     request.headers["X-Token"] = project.project_anchor.token
+    request.headers["X-Dhis2UserId"] = "aze123sdf"
   end
 
   describe "#create" do

--- a/spec/controllers/api/v2/topics_controller_spec.rb
+++ b/spec/controllers/api/v2/topics_controller_spec.rb
@@ -43,7 +43,7 @@ RSpec.describe Api::V2::TopicsController, type: :controller do
            params: payload)
       resp = JSON.parse(response.body)
       expect(resp).to eq("errors" => [
-                           { "status"  => "409",
+                           { "status"  => "400",
                              "message" => "Validation failed: Code has already been taken",
                              "details" => { "code" => ["has already been taken"] } }
                          ])

--- a/spec/factories/activities.rb
+++ b/spec/factories/activities.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :activity do
+  end
+end

--- a/spec/factories/states.rb
+++ b/spec/factories/states.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :state do
+  end
+end


### PR DESCRIPTION
a first create/update api for topic and input mappings (as a nested resource)

I'll merge that to be able to automate my hesabu projet from taskr.
I'm ready to break the api in case you have other preferences.

It's a bit unclear how "relationships" should work so I cheated a bit for the state (allowing to provide a code).
I don't like that serializer don't handle deserialisations, had to play camel vs snake case (or I missed something ?).
Found a lib but we still need to verify "ids" are in within the tenant/project so the added values wasn't clear.
In the problem of our "renaming", validation errors still show the original name (eg state vs input) and are not camelized.
