### PR TITLE
Don't check contracted group when program based

### DIFF
--- a/app/services/invoicing/invoice_entity.rb
+++ b/app/services/invoicing/invoice_entity.rb
@@ -32,6 +32,8 @@ module Invoicing
     def ignore_non_contracted?
       return false unless options.ignore_non_contracted?
 
+      return false if project.entity_group.contract_program_based?
+
       # let it fail later if orgunit not found
       # else check the contracted entity group
       legacy_org_unit = pyramid.org_unit(invoicing_request.entity)
@@ -58,7 +60,7 @@ module Invoicing
             solve_options
           )
           @pyramid = @fetch_and_solve.pyramid
-          @dhis2_export_values = @fetch_and_solve.call
+          @dhis2_export_values = @fetch_and_solve.call      
           @dhis2_input_values = @fetch_and_solve.dhis2_values
           @fetch_and_solve
         end

--- a/spec/fixtures/dhis2/contracts_events.json
+++ b/spec/fixtures/dhis2/contracts_events.json
@@ -1,0 +1,118 @@
+{
+    "pager": {
+      "page": 1,
+      "pageCount": 1698,
+      "total": 3396,
+      "pageSize": 2
+    },
+    "listGrid": {
+      "metaData": {
+        
+      },
+      "headerWidth": 6,
+      "subtitle": "all program events",
+      "width": 6,
+      "title": "all program events",
+      "height": 2,
+      "headers": [
+        {
+          "hidden": false,
+          "meta": false,
+          "name": "event id",
+          "column": "event_id",
+          "type": "java.lang.String"
+        },
+        {
+          "hidden": false,
+          "meta": false,
+          "name": "data values",
+          "column": "data_values",
+          "type": "java.lang.String"
+        },
+        {
+          "hidden": false,
+          "meta": false,
+          "name": "orgunitid",
+          "column": "org_unit_id",
+          "type": "java.lang.String"
+        },
+        {
+          "hidden": false,
+          "meta": false,
+          "name": "orgunitname",
+          "column": "org_unit_name",
+          "type": "java.lang.String"
+        },
+        {
+          "hidden": false,
+          "meta": false,
+          "name": "program_id",
+          "column": "program_id",
+          "type": "java.lang.String"
+        },
+        {
+          "hidden": false,
+          "meta": false,
+          "name": "program_stage_id",
+          "column": "program_stage_id",
+          "type": "java.lang.String"
+        },
+        {
+          "hidden": false,
+          "meta": false,
+          "name": "event date",
+          "column": "event_date",
+          "type": "java.lang.String"
+        },
+        {
+          "hidden": false,
+          "meta": false,
+          "name": "org unit path",
+          "column": "org_unit_path",
+          "type": "java.lang.String"
+        }
+      ],
+      "rows": [
+        [
+          "OgVbqGV2WMH",
+          "{\"LvHWK2BkIJT\": {\"value\": \"2018-06-01\"}, \"vqE7cqNXVYK\": {\"value\": \"2021-12-31\"}, \"xti2FJDgX0U\": {\"value\": \"GROUP_CSI_1_CODE\"}, \"extra2FJDgX0U\":{\"value\":\"GROUP_RURAL_CODE\" }}",
+          "1",
+          "CSI A",
+          "TwcqxaLn11C",
+          "gHPyjsmOXHy"
+        ],
+        [
+          "zIU4tW3NRER",
+          "{\"LvHWK2BkIJT\": {\"value\": \"2018-06-01\" }, \"vqE7cqNXVYK\": {\"value\": \"2021-12-31\" }, \"xti2FJDgX0U\": {\"value\": \"GROUP_CSI_2_CODE\" }, \"extra2FJDgX0U\":{\"value\":\"GROUP_URBAN_CODE\" }}",
+          "2",
+          "CSI B",
+          "TwcqxaLn11C",
+          "gHPyjsmOXHy"
+        ],
+        [
+          "zIU4tW3NRER",
+          "{\"LvHWK2BkIJT\": {\"value\": \"2018-06-01\" }, \"vqE7cqNXVYK\": {\"value\": \"2021-12-31\" }, \"xti2FJDgX0U\": {\"value\": \"GROUP_3_CODE\" }}",
+          "3",
+          "Hospital District",
+          "TwcqxaLn11C",
+          "gHPyjsmOXHy"
+        ],
+        [
+          "zIU4tW3NRER",
+          "{\"LvHWK2BkIJT\": {\"value\": \"2018-06-01\"}, \"vqE7cqNXVYK\": {\"value\": \"2021-12-31\"}, \"xti2FJDgX0U\": {\"value\": null}, \"extra2FJDgX0U\": {\"value\": \"GROUP_X_CODE\"}, \"EBDWBYsJvuz\":{\"value\": \"province_id\"}}",
+          "X",
+          "kl Lareme Centre de Santé",
+          "TwcqxaLn11C",
+          "gHPyjsmOXHy"
+        ],
+        [
+          "zIU4tW3NRER",
+          "{\"LvHWK2BkIJT\": {\"value\": \"2018-06-01\"}, \"vqE7cqNXVYK\": {\"value\": \"2021-12-31\"}, \"xti2FJDgX0U\": {\"value\": null}, \"extra2FJDgX0U\": {\"value\": \"GROUP_PROVINCE_CODE\"}, \"EBDWBYsJvuz\":{\"value\": \"province_id\"}}",
+          "province_id",
+          "Province",
+          "TwcqxaLn11C",
+          "gHPyjsmOXHy"
+        ]
+      ]
+    }
+  }

--- a/spec/fixtures/dhis2/contracts_program.json
+++ b/spec/fixtures/dhis2/contracts_program.json
@@ -1,0 +1,113 @@
+{
+    "name": "FOSA Contrats",
+    "id": "TwcqxaLn11C",
+    "programStages": [
+      {
+        "programStageDataElements": [
+          {
+            "dataElement": {
+              "code": "contract_start_date",
+              "name": "Début contrat",
+              "id": "LvHWK2BkIJT"
+            }
+          },
+          {
+            "dataElement": {
+              "code": "contract_end_date",
+              "name": "Fin de contrat",
+              "id": "vqE7cqNXVYK"
+            }
+          },
+          {
+            "dataElement": {
+              "code": "contract_type",
+              "name": "Type de contrat",
+              "id": "xti2FJDgX0U",
+              "optionSet": {
+                "code": "contractType",
+                "name": "Type de contrat",
+                "id": "fNxAMIQkeHX",
+                "options": [
+                  {
+                    "name": "CSI TYPE I",
+                    "code": "GROUP_CSI_1_CODE",
+                    "id": "LrrQLoDvL0G"
+                  },
+                  {
+                    "name": "CSI TYPE II",
+                    "code": "GROUP_CSI_2_CODE",
+                    "id": "VmmHpOtfEN7"
+                  },
+                  {
+                    "name": "HD",
+                    "code": "GROUP_HD_CODE",
+                    "id": "VmmHpOtfEN8"
+                  },
+                  {
+                    "name": "Province Administration",
+                    "code": "GROUP_PROVINCE_CODE",
+                    "id": "VmmHpOtfEN9"
+                  }
+                ]
+              }
+            }
+          },
+          {
+            "dataElement": {
+              "code": "contract_location",
+              "name": "Location",
+              "id": "extra2FJDgX0U",
+              "optionSet": {
+                "code": "contract_type",
+                "name": "Type de contrat",
+                "id": "fNxAMIQkeHX",
+                "options": [
+                  {
+                    "name": "Rural",
+                    "code": "GROUP_RURAL_CODE",
+                    "id": "XrrQLoDvL0X"
+                  },
+                  {
+                    "name": "Urban",
+                    "code": "GROUP_URBAN_CODE",
+                    "id": "XrrQLoDvL0X"
+                  }
+                ]
+              }
+            }
+          },
+          {
+            "dataElement": {
+              "code": "contract_purshasing_agency",
+              "name": "Purchasing Agency",
+              "id": "extra3Fagency",
+              "optionSet": {
+                "code": "contract_type",
+                "name": "Type de contrat",
+                "id": "fNxAMIQkeHX",
+                "options": [
+                  {
+                    "name": "Agency 1",
+                    "code": "GROUP_PURCHASE_1_CODE",
+                    "id": "XrrQLoDvL0X"
+                  },
+                  {
+                    "name": "Agency 2",
+                    "code": "GROUP_PURCHASE_2_CODE",
+                    "id": "XrrQLoDvL0X"
+                  }
+                ]
+              }
+            }
+          },
+          {
+            "dataElement": {
+              "code": "contract_main_orgunit",
+              "name": "Contract main orgunit",
+              "id": "EBDWBYsJvuz"
+            }
+          }
+        ]
+      }
+    ]
+  }


### PR DESCRIPTION
main change is here : https://github.com/BLSQ/orbf2/pull/235/files#diff-8e9019ed7752a3410a83e8d2c54834fb40ecad7cb687730af00a82cd021f543fR35

if the orgunits is not contracted it will match "0" packages in the later stages since "groups" are deduced from the program events.