### PR TITLE
Use cookies when parallel publishing

### DIFF
--- a/lib/parallel_dhis2.rb
+++ b/lib/parallel_dhis2.rb
@@ -178,6 +178,11 @@ class ParallelDhis2
   # dhis2_client - An instance of `Dhis2::Client`
   def initialize(dhis2_client)
     @client = ClientWrapper.new(dhis2_client)
+    @cookie_jar = Tempfile.new
+  end
+
+  def cookie_file_path
+    @cookie_jar.path
   end
 
   def prepare_payload(payload)
@@ -193,6 +198,8 @@ class ParallelDhis2
                                     method:         :get,
                                     headers:        @client.post_headers,
                                     ssl_verifypeer: @client.ssl_verify_peer?,
+                                    cookiefile:     cookie_file_path, # read from
+                                    cookiejar:      cookie_file_path, # write to
                                     userpwd:        [@client.user, @client.password].join(":"))
     request.run
     request.response
@@ -206,6 +213,8 @@ class ParallelDhis2
                           body:           body,
                           timeout:        @client.time_out_settings,
                           ssl_verifypeer: @client.ssl_verify_peer?,
+                          cookiefile:     cookie_file_path, # read from
+                          cookiejar:      cookie_file_path, # write to
                           userpwd:        [@client.user, @client.password].join(":"))
   end
 


### PR DESCRIPTION
I tried to reuse the existing cookiejar we have in our DHIS gem, but
since that stores the cookies in a ruby hash, like so:

      {"JSESSIONID"	=> "393D14-and-so-on"}

And typhoeus just passes the file where the cookies are on to Ecto,
which is a wrapper for libcurl, which expect the cookies to be in a
file formatted like this:

      # Netscape HTTP Cookie File
      # https://curl.haxx.se/docs/http-cookies.html
      # This file was generated by libcurl! Edit at your own risk.

      #HttpOnly_sandbox.bluesquare.org	FALSE	/	FALSE	0	JSESSIONID	393D14-and-so-on

I tried to fake it by writing the file myself, and giving Typhoeus a
StringIO, but it really needs a file, and since it also has the domain
stuff in it, I figured this might break sooner than that it will help
us.

So, now I just use a tempfile, and the first request of Typhoeus will
fill it, and the others will use it.

So in our DHIS-logs this means one AuthenticationEvent instead of one
per publish action. Which is already a bit of a win in itself.

*Update!*

Since a cookie is just a Header (thanks @mestachs), I could extract if from the internal DHIS2-client, and set it. I'm still using Typhoeus's cookie jar as a backup system, but with the cookie copying, even the first request would no longer be an Authentication event.