### PR TITLE
Change snapshot lookups

### DIFF
--- a/app/models/dhis2_snapshot.rb
+++ b/app/models/dhis2_snapshot.rb
@@ -40,6 +40,19 @@ class Dhis2Snapshot < ApplicationRecord
   KINDS.each do |kind|
     scope kind, -> { where(kind: kind) }
   end
+
+  scope :with_snapshotted_at_lt_eq, -> (date) {
+    end_of_month = Arel.sql("(to_date(concat(year, month),'YYYYMM') + interval '1 month' - interval '1 day')")
+    order_by = Arel.sql("'#{date}' - #{end_of_month}")
+    where(end_of_month.lteq(date)).order(order_by.asc)
+  }
+
+  scope :with_snapshotted_at_gt, -> (date) {
+    end_of_month = Arel.sql("(to_date(concat(year, month),'YYYYMM') + interval '1 month' - interval '1 day')")
+    order_by = Arel.sql("#{end_of_month} - '#{date}'")
+    where(end_of_month.gt(date)).order(order_by.asc)
+  }
+
   has_many :dhis2_snapshot_changes, dependent: :destroy
 
   attr_accessor :disable_tracking

--- a/app/models/dhis2_snapshot.rb
+++ b/app/models/dhis2_snapshot.rb
@@ -37,6 +37,9 @@ class Dhis2Snapshot < ApplicationRecord
              indicators
              category_combos].freeze
 
+  KINDS.each do |kind|
+    scope kind, -> { where(kind: kind) }
+  end
   has_many :dhis2_snapshot_changes, dependent: :destroy
 
   attr_accessor :disable_tracking


### PR DESCRIPTION
Seeing a lot fo these:

```
"ActiveRecord::StatementInvalid: PG::OutOfMemory: ERROR:  out of memory\nDETAIL:  Failed on request of size 39786433 in memory context \"printtup\".\n: SELECT  \"dhis2_snapshots\".* FROM \"dhis2_snapshots\" WHERE \"dhis2_snapshots\".\"project_anchor_id\" = $1 AND \"dhis2_snapshots\".\"id\" = $2 LIMIT $3"}
```

So as a theory, reworking the way we look up the nearest one. Keeping it more in postgres than in ruby. (Theory being that Rails is loading the snapshots with the '*' which is is causing postgres to load all the columns, including a large `jsonb` one, and by using a more selective approach we don't hit that)