### PR TITLE
Display package kind and prevent displaying zone formulas in payment …

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -14,7 +14,7 @@ GIT
 
 GIT
   remote: https://github.com/BLSQ/orbf-rules_engine.git
-  revision: 60f577859c57b412c5025952ffb76885ace6fdb2
+  revision: 9cb90ed296b85a9da4c29913e6cbbc218b9ee5f2
   branch: master
   specs:
     orbf-rules_engine (0.1.0)
@@ -206,7 +206,7 @@ GEM
     httparty (0.16.3)
       mime-types (~> 3.0)
       multi_xml (>= 0.5.2)
-    i18n (1.8.9)
+    i18n (1.8.10)
       concurrent-ruby (~> 1.0)
     immigrant (0.3.6)
       activerecord (>= 3.0)

--- a/app/models/rule_types/payment_rule_type.rb
+++ b/app/models/rule_types/payment_rule_type.rb
@@ -11,7 +11,7 @@ module RuleTypes
     def available_variables
       var_names = []
 
-      rules = payment_rule.packages.flat_map(&:rules).select(&:package_kind?)
+      rules = payment_rule.packages.flat_map(&:rules).select(&:package_kind?).select{|r| r.package.kind != "zone"}
       var_names << rules.flat_map(&:formulas).map(&:code)
       var_names << available_variables_for_values.map { |code| "%{#{code}}" }
 

--- a/app/models/rule_types/payment_rule_type.rb
+++ b/app/models/rule_types/payment_rule_type.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module RuleTypes
   class PaymentRuleType < BaseRuleType
     def initialize(rule)
@@ -11,7 +13,7 @@ module RuleTypes
     def available_variables
       var_names = []
 
-      rules = payment_rule.packages.flat_map(&:rules).select(&:package_kind?).select{|r| r.package.kind != "zone"}
+      rules = payment_rule.packages.flat_map(&:rules).select(&:package_kind?).reject { |r| r.package.kind == "zone" }
       var_names << rules.flat_map(&:formulas).map(&:code)
       var_names << available_variables_for_values.map { |code| "%{#{code}}" }
 

--- a/app/views/setup/project_rules/_form.html.erb
+++ b/app/views/setup/project_rules/_form.html.erb
@@ -1,7 +1,7 @@
 
 <h1><%= rule_name(project_rule.rule) %></h1>
 
-<%= f.association :packages, collection: project_rule.project.packages, as: :check_boxes %>
+<%= f.association :packages, collection: project_rule.project.packages, as: :check_boxes, :label_method => lambda { |package| "#{package.name} : #{package.frequency} , #{package.kind} " } %>
 <%= f.input :frequency , collection: PaymentRule::FREQUENCIES %>
 <%= f.simple_fields_for :rule do |rule_form| %>
   <%= render "setup/rules/form", f: rule_form, rule: project_rule.rule%>

--- a/app/views/setup/setup/_package.html.erb
+++ b/app/views/setup/setup/_package.html.erb
@@ -3,6 +3,8 @@
     <%= link_to package.name , edit_setup_project_package_path(project,package)%>
     <br>
     <br>
+    <small><b>Kind:</b> <%= package.kind %></small>
+    <br>
     <small><b>Frequency:</b>
     <%= package.frequency=%></small>
     <br>

--- a/app/views/setup/setup/_rule.html.erb
+++ b/app/views/setup/setup/_rule.html.erb
@@ -1,7 +1,7 @@
 <tr>
     <td title="<%= package.package_entity_groups.map{ |entitygroup|  %Q(#{entitygroup.name}) }.join(', ') %> - <%= package.states.map{ |state|  %Q(#{state.name}) }.join(', ') %>">
     <%= package.name %><br><br>
-    <%= package.frequency %><br><br>
+    <%= package.kind %>, <%= package.frequency %><br><br>
     <%= package.package_entity_groups.map(&:name).join(",")%>
     </td>
 


### PR DESCRIPTION
 * display the kind and periodicity in payment rules edition screen (and setup page)

![image](https://user-images.githubusercontent.com/371692/117289505-f7adde00-ae6c-11eb-91d4-16aaabd55c6a.png)
![image](https://user-images.githubusercontent.com/371692/117289525-fc729200-ae6c-11eb-9ea0-763d868aaa5a.png)


 * prevent usage of "zone" formulas in payment rules 
     - it's not supposed to work (causing werid errors about formulas not existing), but we still want a payment rules to 