### PR TITLE
Allow some adjustement for local hosting, https, minio for active storage

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ ENV RAILS_SERVE_STATIC_FILES true
 ENV RAILS_LOG_TO_STDOUT true
 # install dependencies and prepare assets for production in one go
 # pass a fake secret key base to let the rake tast run
-RUN bundle config set --local without 'development test' && bundle install && SECRET_KEY_BASE=1 RAILS_ENV=production bundle exec rake assets:precompile
+RUN bundle config set --local without 'development test' && bundle install && DATABASE_URL=nulldb:://null SECRET_KEY_BASE=1 RAILS_ENV=production bundle exec rake assets:precompile --trace
 # Add a script to be executed every time the container starts.
 EXPOSE 3000
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,8 +8,9 @@ RUN gem update --system && gem install bundler -i 2.2.3
 ENV RAILS_ENV production
 ENV RAILS_SERVE_STATIC_FILES true
 ENV RAILS_LOG_TO_STDOUT true
-
-RUN bundle config set --local without 'development test' && bundle install
+# install dependencies and prepare assets for production in one go
+# pass a fake secret key base to let the rake tast run
+RUN bundle config set --local without 'development test' && bundle install && SECRET_KEY_BASE=1 RAILS_ENV=production bundle exec rake assets:precompile
 # Add a script to be executed every time the container starts.
 EXPOSE 3000
 

--- a/Gemfile
+++ b/Gemfile
@@ -18,7 +18,7 @@ gem "pg", "~> 0.18"
 gem "puma", "~> 3.12"
 gem "rack", ">= 2.0.6"
 gem "rails", "~> 5.2", "< 5.3"
-
+gem "activerecord-nulldb-adapter"
 gem "rails_admin", "~> 1.4.2"
 gem "sidekiq", "< 6"
 gem "sidekiq-throttled", "~> 0.9.0"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -68,6 +68,8 @@ GEM
       activemodel (= 5.2.5)
       activesupport (= 5.2.5)
       arel (>= 9.0)
+    activerecord-nulldb-adapter (0.7.0)
+      activerecord (>= 5.2.0, < 6.3)
     activestorage (5.2.5)
       actionpack (= 5.2.5)
       activerecord (= 5.2.5)
@@ -519,6 +521,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  activerecord-nulldb-adapter
   annotate (~> 2.7.4)
   aws-sdk-s3 (~> 1.48)
   bootsnap (~> 1.3.2)

--- a/config/application.rb
+++ b/config/application.rb
@@ -38,6 +38,7 @@ module Scorpio
     end
 
     config.active_job.queue_adapter = :sidekiq
+    config.assets.initialize_on_precompile = false
 
     # These are defined in `/lib/*.rb
     require "scorpio"

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -28,7 +28,7 @@ Rails.application.configure do
 
 
   # Store uploaded files on the local file system (see config/storage.yml for options)
-  config.active_storage.service = :amazon
+  config.active_storage.service = ENV.get(RAILS_ACTIVE_STORAGE, 'amazon')
 
   # Don't care if the mailer can't send.
   config.action_mailer.raise_delivery_errors = false

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -28,7 +28,7 @@ Rails.application.configure do
 
 
   # Store uploaded files on the local file system (see config/storage.yml for options)
-  config.active_storage.service = ENV.get(RAILS_ACTIVE_STORAGE, 'amazon')
+  config.active_storage.service = ENV.fetch("RAILS_ACTIVE_STORAGE", 'amazon')
 
   # Don't care if the mailer can't send.
   config.action_mailer.raise_delivery_errors = false

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -39,7 +39,7 @@ Rails.application.configure do
   # config.action_dispatch.x_sendfile_header = 'X-Accel-Redirect' # for NGINX
 
 
-  config.active_storage.service = :amazon
+  config.active_storage.service = ENV.fetch("RAILS_ACTIVE_STORAGE", 'amazon')
 
   # Mount Action Cable outside main process or domain
   # config.action_cable.mount_path = nil
@@ -47,7 +47,7 @@ Rails.application.configure do
   # config.action_cable.allowed_request_origins = [ 'http://example.com', /http:\/\/example.*/ ]
 
   # Force all access to the app over SSL, use Strict-Transport-Security, and use secure cookies.
-  config.force_ssl = true
+  config.force_ssl = ENV["DISABLE_FORCE_SSL"] == "TRUE" ? false : true
 
   # Prepend all log lines with the following tags.
   config.log_tags = [:request_id]

--- a/config/storage.yml
+++ b/config/storage.yml
@@ -14,6 +14,16 @@ amazon:
   region: <%= ENV["S3_SIMULATION_REGION"] %>
   bucket: <%= ENV["S3_SIMULATION_BUCKET"] %>
 
+# for local hosting : https://kevinjalbert.com/rails-activestorage-configuration-for-minio/
+minio:
+  service: S3
+  access_key_id: <%= ENV["S3_SIMULATION_ACCESS"] %>
+  secret_access_key: <%= ENV["S3_SIMULATION_SECRET"] %>
+  region: <%= ENV["S3_SIMULATION_REGION"] %>
+  bucket: <%= ENV["S3_SIMULATION_BUCKET"] %>
+  endpoint: <%= ENV["S3_SIMULATION_ENDPOINT"] %>
+  force_path_style: true
+
 # Remember not to checkin your GCS keyfile to a repository
 # google:
 #   service: GCS

--- a/lib/tasks/import_export.rake
+++ b/lib/tasks/import_export.rake
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# assuming you have a "production db" we will copy the data of that project in the test db
+# assuming you have we will copy the data of that project in the test db
 #
 # RAILS_ENV=test ./bin/rake db:setup
 # PROJECT_ID=109 bundle exec rake import_export:dump_project

--- a/lib/tasks/import_export.rake
+++ b/lib/tasks/import_export.rake
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+# assuming you have a "production db" we will copy the data of that project in the test db
+#
+# RAILS_ENV=test ./bin/rake db:setup
+# PROJECT_ID=109 bundle exec rake import_export:dump_project
+# pg_dump --column-inserts --data-only -v --no-acl --no-owner --dbname=scorpio_test -f sample.sql
+#
+namespace :import_export do
+  desc "dump"
+  task dump_project: :environment do
+    project = Project.find(ENV.fetch("PROJECT_ID"))
+    program = project.project_anchor.program
+
+    project_includes = Project.deep_clone_includes
+    project_includes[:original] = []
+
+    new_program = program.deep_clone(
+      include:        {
+        users:          [:program],
+        project_anchor: {
+          projects:        project_includes,
+          dhis2_snapshots: []
+        }
+      },
+      use_dictionary: true
+    ) do |original, kopy|
+      if original.class.name == "User"
+        new_password = SecureRandom.uuid
+        kopy.password = new_password
+        kopy.password_confirmation = new_password
+      end
+    end
+
+    database_yml = ERB.new(IO.read("config/database.yml")).result(binding)
+
+    # load instead of safe_load to prevent : Psych::BadAlias: Unknown alias: default
+    dbconfigs = YAML.load(database_yml)
+    dbconfig = dbconfigs["test"]
+    puts "program loaded"
+    ActiveRecord::Base.establish_connection(dbconfig)
+    puts "saving data in #{dbconfig.except('password')}"
+    new_program.save!
+    puts "program is #{new_program.id}"
+  end
+end

--- a/lib/tasks/ui.rake
+++ b/lib/tasks/ui.rake
@@ -56,7 +56,7 @@ namespace :ui do
       log_info "INFO skipping no token for #{project_anchor.project.name} (project_anchor_id : #{project_anchor.id})"
       return
     end
-    config = { url: "https://orbf2.bluesquare.org", token: project_anchor.token }
+    config = { url: ENV.fetch("ORBF2_URL", "https://orbf2.bluesquare.org"), token: project_anchor.token }
     project = project_anchor.project
     dhis2 = Dhis2::Client.new(project.dhis_configuration.merge(timeout: 20))
     log_info "*** setup of token for #{project_anchor.project.name} (project_anchor_id : #{project_anchor.id}, #{project.dhis2_url})"


### PR DESCRIPTION
* the docker image is now bundling production asset at build time
* you can specify DISABLE_FORCE_SSL=TRUE (as it's enforced by traefik)
* to support minio there's 
   * a minio storage entry where you can specify the S3_SIMULATION_ENDPOINT url of minio api
   * RAILS_ACTIVE_STORAGE=minio
* for the "subsetting" of production db : 
   * there's a rake task creating a subset db (loosing ids) https://github.com/moiristo/deep_cloneable/issues/136
* for hesabu manager deployment you can specify the ORBF2_URL (but currently the manager is not versionned)