### PR TITLE
Support for newer review apps

### DIFF
--- a/app.json
+++ b/app.json
@@ -61,9 +61,6 @@
   "addons": ["heroku-postgresql", "heroku-redis"],
   "buildpacks": [
     {
-      "url": "heroku/nodejs"
-    },
-    {
       "url": "heroku/ruby"
     }
   ]


### PR DESCRIPTION
They used to inherit their ENV variables, but in this newer version we
need to supply some defaults.
