### PR TITLE
Scopes to help find snapshots

### DIFF
--- a/app/models/dhis2_snapshot.rb
+++ b/app/models/dhis2_snapshot.rb
@@ -39,6 +39,33 @@ class Dhis2Snapshot < ApplicationRecord
 
   has_many :dhis2_snapshot_changes, dependent: :destroy
 
+  # Generated with:
+  #
+  #       Dhis2Snapshot::KINDS.each do |kind|
+  #         puts "scope :#{kind.to_sym}, -> { where(kind: '#{kind}')}"
+  #       end
+  scope :data_elements, -> { where(kind: 'data_elements')}
+  scope :data_element_groups, -> { where(kind: 'data_element_groups')}
+  scope :organisation_unit_group_sets, -> { where(kind: 'organisation_unit_group_sets')}
+  scope :organisation_unit_groups, -> { where(kind: 'organisation_unit_groups')}
+  scope :organisation_units, -> { where(kind: 'organisation_units')}
+  scope :indicators, -> { where(kind: 'indicators')}
+  scope :category_combos, -> { where(kind: 'category_combos')}
+
+  # If any of the elements inside content match this dhis2_id, the
+  # snapshot will be a match.
+  scope :containing_dhis2_id, -> (id) {
+    part_to_contain = [{table: {id: id}}].to_json
+    where("content @> ?", part_to_contain)
+  }
+
+  # If any of the elements inside content match this display name, the
+  # snapshot will be a match.
+  scope :containing_dhis2_display_name, -> (name) {
+    part_to_contain = [{table: {display_name: name}}].to_json
+    where("content @> ?", part_to_contain)
+  }
+
   attr_accessor :disable_tracking
 
   def kind_organisation_units?

--- a/spec/models/dhis2_snapshot_spec.rb
+++ b/spec/models/dhis2_snapshot_spec.rb
@@ -1,0 +1,56 @@
+require "rails_helper"
+
+RSpec.describe Dhis2Snapshot, type: :model do
+
+  def snapshot_with(content:)
+    project_anchor = FactoryBot.create(:project_anchor)
+    snapshot = Dhis2Snapshot.create!(
+      dhis2_version: "does-not-matter",
+      kind: "does-not-matter",
+      month: 1,
+      year: 1,
+      job_id: "does-not-matter",
+      project_anchor_id: project_anchor.id,
+      content: content
+    )
+  end
+
+  describe 'scopes' do
+    Dhis2Snapshot::KINDS.each do |kind|
+      it "responds to the scope #{kind}" do
+        expect(Dhis2Snapshot.public_send(kind).count).to eq(0)
+      end
+    end
+  end
+
+  describe "containing_dhis2_" do
+    it "will find matching id" do
+      dhis2_id = "fKb766I1Ma9"
+      snapshot = snapshot_with(content: [{"table"=>{"id"=> dhis2_id}}])
+
+      expect(Dhis2Snapshot.containing_dhis2_id(dhis2_id).first).to eq(snapshot)
+    end
+
+    it "will find matching display_name" do
+      dhis2_display_name = "Inigo Montoya"
+      project_anchor = FactoryBot.create(:project_anchor)
+      snapshot = snapshot_with(content: [{"table"=>{"display_name"=> dhis2_display_name}}])
+
+      expect(Dhis2Snapshot.containing_dhis2_display_name(dhis2_display_name).first).to eq(snapshot)
+    end
+
+    it "will not erroneously find matching display_name" do
+      dhis2_display_name = "Inigo Montoya"
+      snapshot = snapshot_with(content: [{"table"=>{"display_name"=> dhis2_display_name}}])
+
+      expect(Dhis2Snapshot.containing_dhis2_display_name("fezzik").first).to eq(nil)
+    end
+
+    it "will not break if the json is not what we expected" do
+      dhis2_display_name = "Inigo Montoya"
+      snapshot = snapshot_with(content: {"o"=>{"hai" => "there"}})
+
+      expect(Dhis2Snapshot.containing_dhis2_display_name("fezzik").count).to eq(0)
+    end
+  end
+end


### PR DESCRIPTION
Sometimes it's handy to find a specific snapshot, or to be able to check if a snapshot has a certain data_element in it.

With these you can now do

      Dhis2Snapshot.where(project_anchor_id: 94).data_elements.containing_dhis2_id("abc123")

And it will give you back if it find any matching snapshots of kind 'data_elements' that had a (dhis2) id in it with 'abc123'