### PR TITLE
formula update endpoints, error handling

### DIFF
--- a/app/controllers/api/v2/base_controller.rb
+++ b/app/controllers/api/v2/base_controller.rb
@@ -25,7 +25,7 @@ module Api
         error = {
           status:  "400",
           message: exception.message,
-          details: exception.record.errors.messages
+          details: exception.record.errors
         }
         render status: :bad_request, json: { errors: [error] }
       end

--- a/app/controllers/api/v2/children_formulas_controller.rb
+++ b/app/controllers/api/v2/children_formulas_controller.rb
@@ -3,14 +3,8 @@
 module Api
   module V2
     class ChildrenFormulasController < FormulasController
-      def find_formula
-        package = current_project_anchor.project.packages.find(params[:set_id])
-        formula = package.multi_entities_rule.formulas.find(params[:id])
-        formula
-      end
-
-      def detailed_relationships
-        %i[used_formulas used_by_formulas]
+      def find_rule 
+        current_project_anchor.project.packages.find(params[:set_id]).multi_entities_rule
       end
     end
   end

--- a/app/controllers/api/v2/compound_formulas_controller.rb
+++ b/app/controllers/api/v2/compound_formulas_controller.rb
@@ -3,14 +3,8 @@
 module Api
   module V2
     class CompoundFormulasController < FormulasController
-      def find_formula
-        payment_rule = current_project_anchor.project.payment_rules.find(params[:compound_id])
-        formula = payment_rule.rule.formulas.find(params[:id])
-        formula
-      end
-
-      def detailed_relationships
-        %i[used_formulas used_by_formulas]
+      def find_rule
+        current_project_anchor.project.payment_rules.find(params[:compound_id]).rule
       end
     end
   end

--- a/app/controllers/api/v2/formulas_controller.rb
+++ b/app/controllers/api/v2/formulas_controller.rb
@@ -27,8 +27,20 @@ module Api
           params: { with_edition_details: true }
         }
 
-        
         formula.update!(formula_attributes)
+
+        options[:include] = default_relationships + detailed_relationships
+        render json: serializer_class.new(formula, options).serialized_json
+      end
+
+      def create
+        formula = create_formula
+
+        formula.reload
+
+        options = {
+          params: { with_edition_details: true }
+        }
 
         options[:include] = default_relationships + detailed_relationships
         render json: serializer_class.new(formula, options).serialized_json
@@ -58,6 +70,7 @@ module Api
         params.require(:data)
               .permit(:type,
                       attributes: %i[
+                        code
                         description
                         exportableFormulaCode
                         expression
@@ -69,6 +82,7 @@ module Api
       def formula_attributes
         att = formula_params[:attributes]
         {
+          code:                          att[:code],
           description:                   att[:description],
           short_name:                    att[:shortName],
           expression:                    att[:expression],

--- a/app/controllers/api/v2/formulas_controller.rb
+++ b/app/controllers/api/v2/formulas_controller.rb
@@ -21,6 +21,19 @@ module Api
         render json: serializer_class.new(formula, options).serialized_json
       end
 
+      def update
+        formula = find_formula
+        options = {
+          params: { with_edition_details: true }
+        }
+
+        
+        formula.update!(formula_attributes)
+
+        options[:include] = default_relationships + detailed_relationships
+        render json: serializer_class.new(formula, options).serialized_json
+      end
+
       private
 
       def default_relationships
@@ -39,6 +52,29 @@ module Api
 
       def serializer_class
         ::V2::FormulaSerializer
+      end
+
+      def formula_params
+        params.require(:data)
+              .permit(:type,
+                      attributes: %i[
+                        description
+                        exportableFormulaCode
+                        expression
+                        frequency
+                        shortName
+                      ])
+      end
+  
+      def formula_attributes
+        att = formula_params[:attributes]
+        {
+          description:                   att[:description],
+          short_name:                    att[:shortName],
+          expression:                    att[:expression],
+          frequency:                     att[:frequency],
+          exportable_formula_code:       att[:exportableFormulaCode]
+        }
       end
     end
   end

--- a/app/controllers/api/v2/formulas_controller.rb
+++ b/app/controllers/api/v2/formulas_controller.rb
@@ -59,8 +59,17 @@ module Api
         options = {
           params: { with_edition_details: true }
         }
+        render json: serializer_class.new(formula, options).serialized_json
+      end
 
-        options[:include] = default_relationships + detailed_relationships
+      def destroy
+        formula = find_formula
+        options = {
+          params: { with_edition_details: true }
+        }
+
+        formula.destroy! unless formula.used_by_formulas.any?
+
         render json: serializer_class.new(formula, options).serialized_json
       end
 

--- a/app/controllers/api/v2/formulas_controller.rb
+++ b/app/controllers/api/v2/formulas_controller.rb
@@ -75,14 +75,21 @@ module Api
 
       private
 
+      def find_formula
+        find_rule.formulas.find(params[:id])
+      end
+
+      def create_formula
+        find_rule.formulas.create!(formula_attributes)
+      end
+
       def default_relationships
         # %i[topics inputs org_unit_groups org_unit_group_sets]
         []
       end
 
       def detailed_relationships
-        # %i[topics.input_mappings] + detailed_formulas_relationships
-        []
+        %i[used_formulas used_by_formulas]
       end
 
       def detailed_formulas_relationships

--- a/app/controllers/api/v2/set_formulas_controller.rb
+++ b/app/controllers/api/v2/set_formulas_controller.rb
@@ -3,14 +3,8 @@
 module Api
   module V2
     class SetFormulasController < FormulasController
-      def find_formula
-        package = current_project_anchor.project.packages.find(params[:set_id])
-        formula = package.package_rule.formulas.find(params[:id])
-        formula
-      end
-
-      def detailed_relationships
-        %i[used_formulas used_by_formulas]
+      def find_rule
+        current_project_anchor.project.packages.find(params[:set_id]).package_rule
       end
     end
   end

--- a/app/controllers/api/v2/topic_formulas_controller.rb
+++ b/app/controllers/api/v2/topic_formulas_controller.rb
@@ -9,6 +9,12 @@ module Api
         formula
       end
 
+      def create_formula
+        package = current_project_anchor.project.packages.find(params[:set_id])
+        formula = package.activity_rule.formulas.create!(formula_attributes)
+        formula
+      end
+
       def detailed_relationships
         %i[used_formulas used_by_formulas]
       end

--- a/app/controllers/api/v2/topic_formulas_controller.rb
+++ b/app/controllers/api/v2/topic_formulas_controller.rb
@@ -3,20 +3,8 @@
 module Api
   module V2
     class TopicFormulasController < FormulasController
-      def find_formula
-        package = current_project_anchor.project.packages.find(params[:set_id])
-        formula = package.activity_rule.formulas.find(params[:id])
-        formula
-      end
-
-      def create_formula
-        package = current_project_anchor.project.packages.find(params[:set_id])
-        formula = package.activity_rule.formulas.create!(formula_attributes)
-        formula
-      end
-
-      def detailed_relationships
-        %i[used_formulas used_by_formulas]
+      def find_rule
+        current_project_anchor.project.packages.find(params[:set_id]).activity_rule
       end
     end
   end

--- a/app/controllers/api/v2/zone_formulas_controller.rb
+++ b/app/controllers/api/v2/zone_formulas_controller.rb
@@ -3,14 +3,8 @@
 module Api
   module V2
     class ZoneFormulasController < FormulasController
-      def find_formula
-        package = current_project_anchor.project.packages.find(params[:set_id])
-        formula = package.zone_rule.formulas.find(params[:id])
-        formula
-      end
-
-      def detailed_relationships
-        %i[used_formulas used_by_formulas]
+      def find_rule
+        current_project_anchor.project.packages.find(params[:set_id]).zone_rule
       end
     end
   end

--- a/app/controllers/api/v2/zone_topic_formulas_controller.rb
+++ b/app/controllers/api/v2/zone_topic_formulas_controller.rb
@@ -3,14 +3,8 @@
 module Api
   module V2
     class ZoneTopicFormulasController < FormulasController
-      def find_formula
-        package = current_project_anchor.project.packages.find(params[:set_id])
-        formula = package.zone_activity_rule.formulas.find(params[:id])
-        formula
-      end
-
-      def detailed_relationships
-        %i[used_formulas used_by_formulas]
+      def find_rule
+        current_project_anchor.project.packages.find(params[:set_id]).zone_activity_rule
       end
     end
   end

--- a/app/models/formula.rb
+++ b/app/models/formula.rb
@@ -88,7 +88,7 @@ class Formula < ApplicationRecord
   end
 
   def frequency=(val)
-    striped = val.strip
+    striped = val.nil? ? val : val.strip
     super(striped.presence)
   end
 

--- a/app/models/package.rb
+++ b/app/models/package.rb
@@ -44,6 +44,9 @@ class Package < ApplicationRecord
 
   has_many :activities, -> { order(code: :asc) }, through: :activity_packages, source: :activity
 
+  has_many :package_payment_rules
+  has_many :payment_rules, through: :package_payment_rules, source: :payment_rule
+
   validates :name, presence: true, length: { maximum: 50 }
 
   validates :frequency, presence: true, inclusion: {

--- a/app/models/rule.rb
+++ b/app/models/rule.rb
@@ -70,6 +70,10 @@ class Rule < ApplicationRecord
     rule_type.used_by_formulas(formula)
   end
 
+  def refactor(formula, new_code)    
+    rule_type.refactor(formula, new_code)
+  end
+
   def parent_id
     kind == RULE_TYPE_PAYMENT ? payment_rule_id : package_id
   end

--- a/app/models/rule_types/package_rule_type.rb
+++ b/app/models/rule_types/package_rule_type.rb
@@ -34,6 +34,17 @@ module RuleTypes
         end
       end 
 
+      rule.package.payment_rules.each do |payment_rule|
+        payment_rule.rule.formulas.each do |f|
+          if f.dependencies.include?("#{formula.code}_values")
+            used_by.push(f) 
+          end
+          if f.dependencies.include?(formula.code)
+            used_by.push(f) 
+          end
+        end
+      end
+
       used_by
     end
 

--- a/app/serializers/v2/formula_serializer.rb
+++ b/app/serializers/v2/formula_serializer.rb
@@ -40,6 +40,11 @@ class V2::FormulaSerializer < V2::BaseSerializer
     object.rule.parent_id
   end
 
+  attributes :errors, if: EDITION_DETAILS do |object, record_serialization_params|
+    object.rule.valid?
+    object.rule.errors
+  end
+
   attributes :kind, if: EDITION_DETAILS do |object, record_serialization_params|
     KIND_TRANSLATION[object.rule.kind]
   end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -45,13 +45,13 @@ Rails.application.routes.draw do
       resources :org_units, only: [:index]
       resources :de_cocs, only: [:index]
       resources :formula_mappings
-      resource :calculations, only: [:show, :create]
+      resource :calculations, only: %i[show create]
       resources :sets, only: %i[index show] do
-        resources :topic_formulas, only: [:show, :update]
-        resources :set_formulas, only: [:show, :update]
-        resources :zone_formulas, only: [:show, :update]
-        resources :children_formulas, only: [:show, :update]
-        resources :zone_topic_formulas, only: [:show, :update]
+        resources :topic_formulas, only: %i[show update create]
+        resources :set_formulas, only: %i[show update create]
+        resources :zone_formulas, only: %i[show update create]
+        resources :children_formulas, only: %i[show update create]
+        resources :zone_topic_formulas, only: %i[show update create]
       end
       resources :compounds, only: %i[index show] do
         resources :compound_formulas, only: [:show]

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -47,11 +47,11 @@ Rails.application.routes.draw do
       resources :formula_mappings
       resource :calculations, only: %i[show create]
       resources :sets, only: %i[index show] do
-        resources :topic_formulas, only: %i[show update create]
-        resources :set_formulas, only: %i[show update create]
-        resources :zone_formulas, only: %i[show update create]
-        resources :children_formulas, only: %i[show update create]
-        resources :zone_topic_formulas, only: %i[show update create]
+        resources :topic_formulas
+        resources :set_formulas
+        resources :zone_formulas
+        resources :children_formulas
+        resources :zone_topic_formulas
       end
       resources :compounds, only: %i[index show] do
         resources :compound_formulas, only: %i[show update create]

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -54,7 +54,7 @@ Rails.application.routes.draw do
         resources :zone_topic_formulas, only: %i[show update create]
       end
       resources :compounds, only: %i[index show] do
-        resources :compound_formulas, only: [:show]
+        resources :compound_formulas, only: %i[show update create]
       end
       resources :simulations, only: %i[index show]
       resources :topics, only: %i[index create update] do

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -47,11 +47,11 @@ Rails.application.routes.draw do
       resources :formula_mappings
       resource :calculations, only: [:show, :create]
       resources :sets, only: %i[index show] do
-        resources :topic_formulas, only: [:show]
-        resources :set_formulas, only: [:show]
-        resources :zone_formulas, only: [:show]
-        resources :children_formulas, only: [:show]
-        resources :zone_topic_formulas, only: [:show]
+        resources :topic_formulas, only: [:show, :update]
+        resources :set_formulas, only: [:show, :update]
+        resources :zone_formulas, only: [:show, :update]
+        resources :children_formulas, only: [:show, :update]
+        resources :zone_topic_formulas, only: [:show, :update]
       end
       resources :compounds, only: %i[index show] do
         resources :compound_formulas, only: [:show]

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -54,7 +54,7 @@ Rails.application.routes.draw do
         resources :zone_topic_formulas
       end
       resources :compounds, only: %i[index show] do
-        resources :compound_formulas, only: %i[show update create]
+        resources :compound_formulas
       end
       resources :simulations, only: %i[index show]
       resources :topics, only: %i[index create update] do

--- a/spec/controllers/api/v2/topic_formulas_controller_spec.rb
+++ b/spec/controllers/api/v2/topic_formulas_controller_spec.rb
@@ -70,4 +70,23 @@ RSpec.describe Api::V2::TopicFormulasController, type: :controller do
       record_json("set.json", resp)
     end
   end
+
+  describe "#update" do
+    include_context "basic_context"
+    include WebmockDhis2Helpers
+
+    it "should return validation errors" do
+      stub_all_pyramid(project_with_packages)
+      request.headers["Accept"] = "application/vnd.api+json;version=2"
+      request.headers["X-Token"] = project_with_packages.project_anchor.token
+      package = project_with_packages.packages.first
+      formula = package.activity_rule.formula("quantity")
+
+      put(:update, params: { set_id: package.id, id: formula.id, data: { id: formula.id, attributes: { shortName: "new", description: "new desc", expression: "if( " } } })
+      resp = JSON.parse(response.body)
+
+      expect(resp).to eq({"errors"=>[{"details"=>{"expression"=>["too many opening parentheses"]}, "message"=>"Validation failed: Expression too many opening parentheses", "status"=>"400"}]}
+      )
+    end
+  end
 end

--- a/spec/controllers/api/v2/topic_formulas_controller_spec.rb
+++ b/spec/controllers/api/v2/topic_formulas_controller_spec.rb
@@ -87,6 +87,17 @@ RSpec.describe Api::V2::TopicFormulasController, type: :controller do
 
       expect(resp).to eq({ "errors"=>[{ "details" => { "expression"=>["too many opening parentheses"] }, "message" => "Validation failed: Expression too many opening parentheses", "status" => "400" }] })
     end
+
+    it "should update errors" do
+      stub_all_pyramid(project_with_packages)
+      request.headers["Accept"] = "application/vnd.api+json;version=2"
+      request.headers["X-Token"] = project_with_packages.project_anchor.token
+      package = project_with_packages.packages.first
+      formula = package.activity_rule.formula("quantity")
+
+      put(:update, params: { set_id: package.id, id: formula.id, data: { id: formula.id, attributes: { code: "new_quantity_code", shortName: "new", description: "new desc", expression: formula.expression } } })
+      resp = JSON.parse(response.body)
+    end
   end
 
   describe "#create" do
@@ -100,10 +111,10 @@ RSpec.describe Api::V2::TopicFormulasController, type: :controller do
       package = project_with_packages.packages.first
 
       post(:create, params: { set_id: package.id, data: { attributes: {
-             code: "test_code",
+             code:        "test_code",
              description: "test",
-             shortName: "test",
-             expression: "2+2",
+             shortName:   "test",
+             expression:  "2+2"
            } } })
 
       resp = JSON.parse(response.body)
@@ -123,14 +134,14 @@ RSpec.describe Api::V2::TopicFormulasController, type: :controller do
       package = project_with_packages.packages.first
 
       post(:create, params: { set_id: package.id, data: { attributes: {
-             code: "test_code",
-             shortName: "test",
-             expression: "2+2",
+             code:       "test_code",
+             shortName:  "test",
+             expression: "2+2"
            } } })
 
       resp = JSON.parse(response.body)
 
-      expect(resp).to eq({"errors"=>[{"status"=>"400", "message"=>"Validation failed: Description can't be blank", "details"=>{"description"=>["can't be blank"]}}]})
+      expect(resp).to eq({ "errors"=>[{ "status" => "400", "message" => "Validation failed: Description can't be blank", "details" => { "description"=>["can't be blank"] } }] })
     end
   end
 end


### PR DESCRIPTION
This PR adds an update endpoint for formulas, accessible by hesabu-manager. It also adjusts how errors are handled and sent back up to the client so that there is more precise information about validation errors for specific attributes. 
