### PR TITLE
Force dhis2 user id when showing/creating/deleting

### DIFF
--- a/app/controllers/api/v2/formulas_controller.rb
+++ b/app/controllers/api/v2/formulas_controller.rb
@@ -3,13 +3,7 @@
 module Api
   module V2
     class FormulasController < BaseController
-      # def index
-      #   packages = current_project_anchor.project.packages
-      #   options = {}
-      #   options[:include] = default_relationships
-
-      #   render json: serializer_class.new(packages, options).serialized_json
-      # end
+      before_action :check_whodunnit!
 
       def show
         formula = find_formula

--- a/app/views/setup/changes/index.erb
+++ b/app/views/setup/changes/index.erb
@@ -21,7 +21,7 @@
         <% end %>
       </td>
       <td><%= version.event %></td>
-      <td><%= version.author ? version.author.email : "System" %></td>
+      <td><%= version.author ? version.author.email : version.whodunnit || "System" %></td>
       <td><%= time_ago_in_words(version.created_at) %> </td>
 			<td>
         <small>

--- a/spec/controllers/api/v2/children_formulas_controller_spec.rb
+++ b/spec/controllers/api/v2/children_formulas_controller_spec.rb
@@ -37,16 +37,6 @@ RSpec.describe Api::V2::ChildrenFormulasController, type: :controller do
   let(:program) { create :program }
   let(:token) { "123456789" }
 
-  let(:project_without_packages) do
-    project = build :project
-    project.project_anchor = program.build_project_anchor(token: token)
-    project.save!
-    user.program = program
-    user.save!
-    user.reload
-    project
-  end
-
   let(:project_with_packages) do
     project = full_project
     project.project_anchor.update(token: token)
@@ -57,27 +47,40 @@ RSpec.describe Api::V2::ChildrenFormulasController, type: :controller do
     project
   end
 
+  def authenticated
+    request.headers["Accept"] = "application/vnd.api+json;version=2"
+    request.headers["X-Token"] = token
+    request.headers["X-Dhis2UserId"] = "aze123sdf"
+  end
+
   describe "#show" do
     include_context "basic_context"
     include WebmockDhis2Helpers
 
+    before do
+      authenticated
+    end
+
     it "returns not found for non existing formula" do
-      request.headers["Accept"] = "application/vnd.api+json;version=2"
-      request.headers["X-Token"] = project_without_packages.project_anchor.token
-      get(:show, params: { set_id: "123abcd", id: "abdc123" })
+      stub_all_pyramid(project_with_packages)
+      with_multi_entity_rule(project_with_packages)
+      package = project_with_packages.packages.first
+      formula = package.multi_entities_rule.formulas.first
+
+      get(:show, params: { set_id: package.id, id: "abdc123" })
+
       _resp = JSON.parse(response.body)
       expect(response.status).to eq(404)
     end
 
     it "returns formula data for existing formula" do
       stub_all_pyramid(project_with_packages)
-      request.headers["Accept"] = "application/vnd.api+json;version=2"
-      request.headers["X-Token"] = project_with_packages.project_anchor.token
       with_multi_entity_rule(project_with_packages)
       package = project_with_packages.packages.first
       formula = package.multi_entities_rule.formulas.first
 
       get(:show, params: { set_id: package.id, id: formula.id })
+
       resp = JSON.parse(response.body)
       expect(resp["data"]["id"]).to eq(formula.id.to_s)
       expect(resp["data"]["attributes"]["availableVariables"]).to eq(formula.rule.available_variables)

--- a/spec/controllers/api/v2/compound_formulas_controller_spec.rb
+++ b/spec/controllers/api/v2/compound_formulas_controller_spec.rb
@@ -6,16 +6,6 @@ RSpec.describe Api::V2::CompoundFormulasController, type: :controller do
   let(:program) { create :program }
   let(:token) { "123456789" }
 
-  let(:project_without_packages) do
-    project = build :project
-    project.project_anchor = program.build_project_anchor(token: token)
-    project.save!
-    user.program = program
-    user.save!
-    user.reload
-    project
-  end
-
   let(:project_with_packages) do
     project = full_project
     project.project_anchor.update(token: token)
@@ -26,28 +16,37 @@ RSpec.describe Api::V2::CompoundFormulasController, type: :controller do
     project
   end
 
+  def authenticated
+    request.headers["Accept"] = "application/vnd.api+json;version=2"
+    request.headers["X-Token"] = token
+    request.headers["X-Dhis2UserId"] = "aze123sdf"
+  end  
+
   describe "#show" do
     include_context "basic_context"
 
+    before do
+      authenticated
+    end
+
     it "returns not found for non existing compound" do
-      request.headers["Accept"] = "application/vnd.api+json;version=2"
-      request.headers["X-Token"] = project_without_packages.project_anchor.token
-      get(:show, params: { compound_id: "abdc123", id: "123abcd" })
+
+      get(:show, params: { compound_id: project_with_packages.payment_rules.first.id, id: "123abcd" })
+
       _resp = JSON.parse(response.body)
       expect(response.status).to eq(404)
     end
 
     it "returns formula for existing compound" do
-      request.headers["Accept"] = "application/vnd.api+json;version=2"
-      request.headers["X-Token"] = project_with_packages.project_anchor.token
       payment_rule = project_with_packages.payment_rules.first
       formula = payment_rule.rule.formulas.first
+
       get(:show, params: { compound_id: payment_rule.id, id: formula.id })
+
       resp = JSON.parse(response.body)
       expect(resp["data"]["id"]).to eq(formula.id.to_s)
       expect(resp["data"]["attributes"]["availableVariables"]).to eq(formula.rule.available_variables)
       expect(resp["data"]["attributes"]["mockValues"]).to eq({})
-      record_json("compound.json", resp)
     end
   end
 end

--- a/spec/controllers/api/v2/set_formulas_controller_spec.rb
+++ b/spec/controllers/api/v2/set_formulas_controller_spec.rb
@@ -19,16 +19,6 @@ RSpec.describe Api::V2::SetFormulasController, type: :controller do
   let(:program) { create :program }
   let(:token) { "123456789" }
 
-  let(:project_without_packages) do
-    project = build :project
-    project.project_anchor = program.build_project_anchor(token: token)
-    project.save!
-    user.program = program
-    user.save!
-    user.reload
-    project
-  end
-
   let(:project_with_packages) do
     project = full_project
     project.project_anchor.update(token: token)
@@ -39,32 +29,44 @@ RSpec.describe Api::V2::SetFormulasController, type: :controller do
     project
   end
 
+  def authenticated
+    request.headers["Accept"] = "application/vnd.api+json;version=2"
+    request.headers["X-Token"] = token
+    request.headers["X-Dhis2UserId"] = "aze123sdf"
+  end
+
   describe "#show" do
     include_context "basic_context"
     include WebmockDhis2Helpers
 
+    before do
+      authenticated
+    end
+
     it "returns not found for non existing formula" do
-      request.headers["Accept"] = "application/vnd.api+json;version=2"
-      request.headers["X-Token"] = project_without_packages.project_anchor.token
-      get(:show, params: { set_id: "123abcd", id: "abdc123" })
+      stub_all_pyramid(project_with_packages)
+
+      package = project_with_packages.packages.first
+      formula = package.package_rule.formulas.first
+
+      get(:show, params: { set_id: package.id, id: "abdc123" })
+
       _resp = JSON.parse(response.body)
       expect(response.status).to eq(404)
     end
 
     it "returns formula data for existing formula" do
       stub_all_pyramid(project_with_packages)
-      request.headers["Accept"] = "application/vnd.api+json;version=2"
-      request.headers["X-Token"] = project_with_packages.project_anchor.token
+
       package = project_with_packages.packages.first
       formula = package.package_rule.formulas.first
 
       get(:show, params: { set_id: package.id, id: formula.id })
+
       resp = JSON.parse(response.body)
       expect(resp["data"]["id"]).to eq(formula.id.to_s)
       expect(resp["data"]["attributes"]["availableVariables"]).to eq(formula.rule.available_variables)
       expect(resp["data"]["attributes"]["mockValues"]).to eq({})
-
-      record_json("set.json", resp)
     end
   end
 end

--- a/spec/controllers/api/v2/zone_formulas_controller_spec.rb
+++ b/spec/controllers/api/v2/zone_formulas_controller_spec.rb
@@ -19,16 +19,6 @@ RSpec.describe Api::V2::ZoneFormulasController, type: :controller do
   let(:program) { create :program }
   let(:token) { "123456789" }
 
-  let(:project_without_packages) do
-    project = build :project
-    project.project_anchor = program.build_project_anchor(token: token)
-    project.save!
-    user.program = program
-    user.save!
-    user.reload
-    project
-  end
-
   let(:project_with_packages) do
     project = full_project
     project.project_anchor.update(token: token)
@@ -39,36 +29,54 @@ RSpec.describe Api::V2::ZoneFormulasController, type: :controller do
     project
   end
 
+  let(:package) do 
+    package = project_with_packages.packages.first
+    package.rules.create!(
+      name: "QUALITY score",
+      kind: "zone",
+      formulas_attributes: [{
+        code:        "zone_formula",
+        short_name:  "short",
+        expression:  "10+10",
+        description: "pma for the zone"
+      }]
+    )
+
+    package
+  end
+
+  let(:formula) do 
+    formula = package.zone_rule.formulas.first
+  end
+
+  def authenticated
+    request.headers["Accept"] = "application/vnd.api+json;version=2"
+    request.headers["X-Token"] = token
+    request.headers["X-Dhis2UserId"] = "aze123sdf"
+  end
+
   describe "#show" do
     include_context "basic_context"
     include WebmockDhis2Helpers
 
+    before do
+      authenticated
+    end
+
     it "returns not found for non existing formula" do
-      request.headers["Accept"] = "application/vnd.api+json;version=2"
-      request.headers["X-Token"] = project_without_packages.project_anchor.token
-      get(:show, params: { set_id: "123abcd", id: "abdc123" })
-      _resp = JSON.parse(response.body)
+      stub_all_pyramid(project_with_packages)
+
+      get(:show, params: { set_id: package.id, id: "abdc123" })
+
+      resp = JSON.parse(response.body)
       expect(response.status).to eq(404)
     end
 
     it "returns formula data for existing formula" do
       stub_all_pyramid(project_with_packages)
-      request.headers["Accept"] = "application/vnd.api+json;version=2"
-      request.headers["X-Token"] = project_with_packages.project_anchor.token
-      package = project_with_packages.packages.first
-      package.rules.create!(
-        name: "QUALITY score",
-        kind: "zone",
-        formulas_attributes: [{
-          code:        "zone_formula",
-          short_name:  "short",
-          expression:  "10+10",
-          description: "pma for the zone"
-        }]
-      )
-
-      formula = package.zone_rule.formulas.first
+      
       get(:show, params: { set_id: package.id, id: formula.id })
+
       resp = JSON.parse(response.body)
       expect(resp["data"]["id"]).to eq(formula.id.to_s)
       expect(resp["data"]["attributes"]["availableVariables"]).to eq(formula.rule.available_variables)


### PR DESCRIPTION
the whodunnit wasn't filled, it is now.

![image](https://user-images.githubusercontent.com/371692/181707775-ef4002c0-c737-4d67-b41d-36238ce4432e.png)
